### PR TITLE
Fixes for linux #1

### DIFF
--- a/SIT.Manager.Avalonia/SIT.Manager.Avalonia.csproj
+++ b/SIT.Manager.Avalonia/SIT.Manager.Avalonia.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="PeNet" Version="4.0.4" />
+    <PackageReference Include="SharpCompress" Version="0.36.0" />
     <PackageReference Include="SkiaSharp" Version="2.88.7" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <PackageReference Include="ThemeEditor.Controls.ColorPicker" Version="11.0.0" />

--- a/SIT.Manager.Avalonia/Services/InstallerService.cs
+++ b/SIT.Manager.Avalonia/Services/InstallerService.cs
@@ -100,14 +100,18 @@ namespace SIT.Manager.Avalonia.Services
         /// Runs the downgrade patcher
         /// </summary>
         /// <returns>string with result</returns>
-        private async Task<string> RunPatcher() {
+        private async Task<string> RunPatcher()
+        {
             _logger.LogInformation("Starting Patcher");
             _actionNotificationService.StartActionNotification();
             _actionNotificationService.UpdateActionNotification(new ActionNotification("Running Patcher...", 100));
 
             string patcherPath = Path.Combine(_configService.Config.InstallPath, "Patcher.exe");
             if (!File.Exists(patcherPath)) {
+                patcherPath = Path.Combine(_configService.Config.InstallPath, "patcher.exe");
+                if (!File.Exists(patcherPath)) {
                 return $"Patcher.exe not found at {patcherPath}";
+            }
             }
 
             Process patcherProcess = new() {


### PR DESCRIPTION
There's almost certainly more but these were two things I found on Linux yesterday.

The first is that the patcher could be called patcher.exe rather than Patcher.exe.

Then the second is if the zip file was compressed using lzma it would fail but with the SharpCompress package it's fine. The original manager used this but somehow I missed that.