### PR TITLE
Fix config wiping saved credentials

### DIFF
--- a/SIT.Manager.Avalonia/Services/ManagerConfigService.cs
+++ b/SIT.Manager.Avalonia/Services/ManagerConfigService.cs
@@ -46,8 +46,9 @@ namespace SIT.Manager.Avalonia.Services
         }
 
 
-        public void UpdateConfig(ManagerConfig config, bool ShouldSave = true, bool SaveAccount = false) {
+        public void UpdateConfig(ManagerConfig config, bool ShouldSave = true, bool? SaveAccount = null) {
             _config = config;
+            SaveAccount ??= config.RememberLogin;
 
             var options = new JsonSerializerOptions() {
                 Converters = {
@@ -58,7 +59,7 @@ namespace SIT.Manager.Avalonia.Services
 
             if (ShouldSave) {
                 ManagerConfig newLauncherConfig = _config;
-                if (!SaveAccount) {
+                if (!SaveAccount.Value) {
                     newLauncherConfig.Username = string.Empty;
                     newLauncherConfig.Password = string.Empty;
                 }


### PR DESCRIPTION
I was wondering why my credentials kept resetting and it's because I'm stupid. If we didn't specific to remember login when updating the config it would default to false instead of the last used value, meaning any config not explicitly stating to remember would null out saved credentials