### PR TITLE
Add ApplicationIcon entry

### DIFF
--- a/SIT.Manager.Avalonia.Desktop/SIT.Manager.Avalonia.Desktop.csproj
+++ b/SIT.Manager.Avalonia.Desktop/SIT.Manager.Avalonia.Desktop.csproj
@@ -11,6 +11,7 @@
 		One for Windows with net7.0-windows TFM, one for MacOS with net7.0-macos and one with net7.0 TFM for Linux.-->
 		<TargetFramework>net8.0</TargetFramework>
 		<TrimMode>CopyUsed</TrimMode>
+		<ApplicationIcon>../SIT.Manager.Avalonia/Assets/Stay-In-Tarkov-512.ico</ApplicationIcon>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Sets the executable icon for Windows builds.

Wasn't sure whether to move the .ico file into the desktop project folder or leave it. Figured leaving it was simpler.