### PR TITLE
Switch versioning to a different method

### DIFF
--- a/SIT.Manager.Avalonia/AssemblyInfo.cs
+++ b/SIT.Manager.Avalonia/AssemblyInfo.cs
@@ -11,4 +11,4 @@ using System.Runtime.Versioning;
 [assembly: AssemblyCulture("")]
 [assembly: SupportedOSPlatform("windows")]
 [assembly: SupportedOSPlatform("linux")]
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.8837.*")]


### PR DESCRIPTION
Using this method should make updating for linux easier to setup as the verisons will be consistent on builds between Windows and Linux, unless they somehow are build just before and after midnight.

Example version is now 1.0.8837.39476

So we now have to manuall update the first 3 values but that shouldn't be too much effort to handle