### PR TITLE
Activate views differently

### DIFF
--- a/SIT.Manager.Avalonia.Desktop/Program.cs
+++ b/SIT.Manager.Avalonia.Desktop/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia;
-using Avalonia.ReactiveUI;
 using System;
 
 namespace SIT.Manager.Avalonia.Desktop;
@@ -18,6 +17,5 @@ class Program
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .WithInterFont()
-            .LogToTrace()
-            .UseReactiveUI();
+            .LogToTrace();
 }

--- a/SIT.Manager.Avalonia/Controls/ActivatableUserControl.cs
+++ b/SIT.Manager.Avalonia/Controls/ActivatableUserControl.cs
@@ -1,0 +1,40 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SIT.Manager.Avalonia.Controls;
+
+public class ActivatableUserControl : UserControl
+{
+    public ObservableRecipient? ViewModel => DataContext is ObservableRecipient dc ? dc : default;
+
+    public ActivatableUserControl()
+    {
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        if (ViewModel != null)
+        {
+            ViewModel.IsActive = true;
+            OnActivated();
+        }
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+
+        if (ViewModel != null)
+        {
+            ViewModel.IsActive = false;
+            OnDeactivated();
+        }
+    }
+
+    protected virtual void OnActivated() { }
+
+    protected virtual void OnDeactivated() { }
+}

--- a/SIT.Manager.Avalonia/SIT.Manager.Avalonia.csproj
+++ b/SIT.Manager.Avalonia/SIT.Manager.Avalonia.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.10" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.10" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.10" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.10" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/SIT.Manager.Avalonia/ViewModels/Dialogs/SelectDowngradePatcherMirrorDialogViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/Dialogs/SelectDowngradePatcherMirrorDialogViewModel.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace SIT.Manager.Avalonia.ViewModels.Dialogs;
 
-public partial class SelectDowngradePatcherMirrorDialogViewModel : ViewModelBase
+public partial class SelectDowngradePatcherMirrorDialogViewModel : ObservableObject
 {
     [ObservableProperty]
     private KeyValuePair<string, string>? _selectedMirror;

--- a/SIT.Manager.Avalonia/ViewModels/Dialogs/SelectEditionDialogViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/Dialogs/SelectEditionDialogViewModel.cs
@@ -1,20 +1,23 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
-using DynamicData;
 using SIT.Manager.Avalonia.Models;
 using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace SIT.Manager.Avalonia.ViewModels.Dialogs;
 
-public partial class SelectEditionDialogViewModel : ViewModelBase
+public partial class SelectEditionDialogViewModel : ObservableObject
 {
     [ObservableProperty]
     private TarkovEdition? _selectedEdition = null;
 
     public ObservableCollection<TarkovEdition> Editions { get; } = [];
+
     public SelectEditionDialogViewModel(TarkovEdition[] editions)
     {
-        Editions.AddRange(editions);
+        foreach (TarkovEdition edition in editions)
+        {
+            Editions.Add(edition);
+        }
         SelectedEdition = Editions.FirstOrDefault();
     }
 }

--- a/SIT.Manager.Avalonia/ViewModels/Dialogs/SelectVersionDialogViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/Dialogs/SelectVersionDialogViewModel.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace SIT.Manager.Avalonia.ViewModels.Dialogs;
 
-public partial class SelectVersionDialogViewModel : ViewModelBase
+public partial class SelectVersionDialogViewModel : ObservableObject
 {
     [ObservableProperty]
     private GithubRelease? _selectedVersion;

--- a/SIT.Manager.Avalonia/ViewModels/LocationEditorViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/LocationEditorViewModel.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace SIT.Manager.Avalonia.ViewModels;
 
-public partial class LocationEditorViewModel : ViewModelBase
+public partial class LocationEditorViewModel : ObservableObject
 {
     private readonly IBarNotificationService _barNotificationService;
     private readonly IPickerDialogService _pickerDialogService;

--- a/SIT.Manager.Avalonia/ViewModels/MainViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/MainViewModel.cs
@@ -68,8 +68,6 @@ public partial class MainViewModel : ObservableRecipient, IRecipient<PageNavigat
         _actionNotificationService.ActionNotificationReceived += ActionNotificationService_ActionNotificationReceived;
         _barNotificationService.BarNotificationReceived += BarNotificationService_BarNotificationReceived;
 
-        WeakReferenceMessenger.Default.Register(this);
-
         UpdateButtonCommand = new AsyncRelayCommand(UpdateButton);
         CloseButtonCommand = new RelayCommand(() => { UpdateAvailable = false; });
 
@@ -164,6 +162,7 @@ public partial class MainViewModel : ObservableRecipient, IRecipient<PageNavigat
 
     protected override async void OnActivated()
     {
+        base.OnActivated();
         await CheckForUpdate();
     }
 

--- a/SIT.Manager.Avalonia/ViewModels/MainViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/MainViewModel.cs
@@ -7,7 +7,6 @@ using FluentAvalonia.Styling;
 using FluentAvalonia.UI.Controls;
 using FluentAvalonia.UI.Media.Animation;
 using Microsoft.Extensions.Logging;
-using ReactiveUI;
 using SIT.Manager.Avalonia.Interfaces;
 using SIT.Manager.Avalonia.ManagedProcess;
 using SIT.Manager.Avalonia.Models;
@@ -19,13 +18,12 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Reactive.Disposables;
 using System.Reflection;
 using System.Threading.Tasks;
 
 namespace SIT.Manager.Avalonia.ViewModels;
 
-public partial class MainViewModel : ViewModelBase, IRecipient<PageNavigationMessage>
+public partial class MainViewModel : ObservableRecipient, IRecipient<PageNavigationMessage>
 {
     private const string MANAGER_VERSION_URL = @"https://raw.githubusercontent.com/stayintarkov/SIT.Manager.Avalonia/master/VERSION";
     private readonly IActionNotificationService _actionNotificationService;
@@ -75,10 +73,6 @@ public partial class MainViewModel : ViewModelBase, IRecipient<PageNavigationMes
         UpdateButtonCommand = new AsyncRelayCommand(UpdateButton);
         CloseButtonCommand = new RelayCommand(() => { UpdateAvailable = false; });
 
-        this.WhenActivated(async (CompositeDisposable disposables) =>
-        {
-            await CheckForUpdate();
-        });
         _managerConfigService.ConfigChanged += async (o, c) => await CheckForUpdate();
     }
 
@@ -166,6 +160,11 @@ public partial class MainViewModel : ViewModelBase, IRecipient<PageNavigationMes
             return false;
         }
         return contentFrame?.Navigate(page, null, suppressTransition ? new SuppressNavigationTransitionInfo() : null) ?? false;
+    }
+
+    protected override async void OnActivated()
+    {
+        await CheckForUpdate();
     }
 
     public void RegisterContentFrame(Frame frame)

--- a/SIT.Manager.Avalonia/ViewModels/ModsPageViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/ModsPageViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
-using ReactiveUI;
 using SIT.Manager.Avalonia.Interfaces;
 using SIT.Manager.Avalonia.ManagedProcess;
 using SIT.Manager.Avalonia.Models;
@@ -10,13 +9,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Reactive.Disposables;
 using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace SIT.Manager.Avalonia.ViewModels;
 
-public partial class ModsPageViewModel : ViewModelBase
+public partial class ModsPageViewModel : ObservableRecipient
 {
     private readonly IBarNotificationService _barNotificationService;
     private readonly IManagerConfigService _managerConfigService;
@@ -64,17 +62,6 @@ public partial class ModsPageViewModel : ViewModelBase
         DownloadModPackageCommand = new AsyncRelayCommand(DownloadModPackage);
         InstallModCommand = new AsyncRelayCommand(InstallMod);
         UninstallModCommand = new AsyncRelayCommand(UninstallMod);
-
-        this.WhenActivated(async (CompositeDisposable disposables) =>
-        {
-            /* Handle activation */
-            await LoadMasterList();
-
-            Disposable.Create(() =>
-            {
-                /* Handle deactivation */
-            }).DisposeWith(disposables);
-        });
     }
 
     private async Task LoadMasterList()
@@ -196,5 +183,10 @@ public partial class ModsPageViewModel : ViewModelBase
 
         bool uninstallSuccessful = await _modService.UninstallMod(SelectedMod);
         EnableInstall = uninstallSuccessful;
+    }
+
+    protected override async void OnActivated()
+    {
+        await LoadMasterList();
     }
 }

--- a/SIT.Manager.Avalonia/ViewModels/PlayPageViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/PlayPageViewModel.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
+﻿using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -23,7 +22,7 @@ using System.Threading.Tasks;
 
 namespace SIT.Manager.Avalonia.ViewModels;
 
-public partial class PlayPageViewModel : ViewModelBase
+public partial class PlayPageViewModel : ObservableObject
 {
     //TODO: Merge these constants into one play. Pretty sure we delcare at least one of these somewhere else already
     private const string SIT_DLL_FILENAME = "StayInTarkov.dll";

--- a/SIT.Manager.Avalonia/ViewModels/SettingsPageViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/SettingsPageViewModel.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace SIT.Manager.Avalonia.ViewModels;
 
-public partial class SettingsPageViewModel : ViewModelBase
+public partial class SettingsPageViewModel : ObservableObject
 {
     private readonly IManagerConfigService _configsService;
     private readonly ILocalizationService _localizationService;

--- a/SIT.Manager.Avalonia/ViewModels/ToolsPageViewModel.cs
+++ b/SIT.Manager.Avalonia/ViewModels/ToolsPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Mvvm.Input;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using FluentAvalonia.UI.Controls;
 using SIT.Manager.Avalonia.Interfaces;
@@ -16,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace SIT.Manager.Avalonia.ViewModels;
 
-public partial class ToolsPageViewModel : ViewModelBase
+public partial class ToolsPageViewModel : ObservableObject
 {
     private readonly IAkiServerService _akiServerService;
     private readonly IBarNotificationService _barNotificationService;

--- a/SIT.Manager.Avalonia/ViewModels/ViewModelBase.cs
+++ b/SIT.Manager.Avalonia/ViewModels/ViewModelBase.cs
@@ -1,9 +1,0 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-using ReactiveUI;
-
-namespace SIT.Manager.Avalonia.ViewModels;
-
-public class ViewModelBase : ObservableObject, IActivatableViewModel
-{
-    public ViewModelActivator Activator { get; } = new ViewModelActivator();
-}

--- a/SIT.Manager.Avalonia/Views/MainView.axaml
+++ b/SIT.Manager.Avalonia/Views/MainView.axaml
@@ -51,9 +51,12 @@
 				</ItemsControl.ItemTemplate>
 			</ItemsControl>
 		</StackPanel>
+		
+		
 
 		<ui:NavigationView PaneDisplayMode="Left"
 						   IsBackButtonVisible="False"
+						   IsSettingsVisible="False"
 						   IsPaneToggleButtonVisible="False"
 						   OpenPaneLength="166"
 						   Grid.Row="1"
@@ -71,6 +74,10 @@
 				<ui:NavigationViewItem IconSource="MapDrive" Content="{DynamicResource ServerTitle}" Tag="SIT.Manager.Avalonia.Views.ServerPage" ToolTip.Tip="{DynamicResource ServerTitleToolTip}"/>
 				<ui:NavigationViewItem IconSource="Library" Content="{DynamicResource ModsTitle}" Tag="SIT.Manager.Avalonia.Views.ModsPage" ToolTip.Tip="{DynamicResource ModsTitleToolTip}"/>
 			</ui:NavigationView.MenuItems>
+
+			<ui:NavigationView.FooterMenuItems>
+				<ui:NavigationViewItem IconSource="Settings" Content="{DynamicResource SettingsTitle}" Tag="SIT.Manager.Avalonia.Views.SettingsPage"/>
+			</ui:NavigationView.FooterMenuItems>		
 
 			<Grid RowDefinitions="*,Auto">
 				<ui:Frame Name="ContentFrame" Margin="2" CornerRadius="8">

--- a/SIT.Manager.Avalonia/Views/MainView.axaml.cs
+++ b/SIT.Manager.Avalonia/Views/MainView.axaml.cs
@@ -1,10 +1,6 @@
-using Avalonia.ReactiveUI;
 using CommunityToolkit.Mvvm.Messaging;
 using FluentAvalonia.UI.Controls;
-using Microsoft.Extensions.DependencyInjection;
-using ReactiveUI;
-using SIT.Manager.Avalonia.Interfaces;
-using SIT.Manager.Avalonia.ManagedProcess;
+using SIT.Manager.Avalonia.Controls;
 using SIT.Manager.Avalonia.Models;
 using SIT.Manager.Avalonia.Models.Messages;
 using SIT.Manager.Avalonia.ViewModels;
@@ -13,39 +9,15 @@ using System.Linq;
 
 namespace SIT.Manager.Avalonia.Views;
 
-public partial class MainView : ReactiveUserControl<MainViewModel>
+public partial class MainView : ActivatableUserControl
 {
-    private readonly ILocalizationService? _localizationService = App.Current.Services.GetService<ILocalizationService>();
-    private readonly IManagerConfigService? _configService = App.Current.Services.GetService<IManagerConfigService>();
-    private string lastSelectedLanguage = string.Empty;
     public MainView()
     {
         InitializeComponent();
 
-        // Set the initially loaded page to be the play page and highlight this
-        // in the nav view.
+        // Set the initially loaded page to be the play page and highlight this in the nav view.
         ContentFrame.Navigate(typeof(PlayPage));
         NavView.SelectedItem = NavView.MenuItems.First();
-
-        // MainViewModel's WhenActivated block will also get called.
-        this.WhenActivated(disposables =>
-        {
-            /* Handle view activation etc. */
-            if (DataContext is MainViewModel dataContext)
-            {
-                // Register the content frame so that we can update it from the view model
-                dataContext.RegisterContentFrame(ContentFrame);
-                if (_configService != null) _configService.ConfigChanged += (o, e) =>
-                {
-                    if (lastSelectedLanguage != e.CurrentLanguageSelected || string.IsNullOrEmpty(lastSelectedLanguage))
-                    {
-                        lastSelectedLanguage = e.CurrentLanguageSelected;
-                        NavView.SettingsItem.Content = _localizationService?.TranslateSource("SettingsTitle");
-                    }
-                };
-                NavView.SettingsItem.Content = _localizationService?.TranslateSource("SettingsTitle");
-            }
-        });
     }
 
     // I hate this so much, Please if someone knows of a better way to do this make a pull request. Even microsoft docs recommend this heathenry
@@ -68,6 +40,15 @@ public partial class MainView : ReactiveUserControl<MainViewModel>
         if (pageNavigation != null)
         {
             WeakReferenceMessenger.Default.Send(new PageNavigationMessage(pageNavigation));
+        }
+    }
+
+    protected override void OnActivated()
+    {
+        if (DataContext is MainViewModel dataContext)
+        {
+            // Register the content frame so that we can update it from the view model
+            dataContext.RegisterContentFrame(ContentFrame);
         }
     }
 }

--- a/SIT.Manager.Avalonia/Views/ModsPage.axaml.cs
+++ b/SIT.Manager.Avalonia/Views/ModsPage.axaml.cs
@@ -1,17 +1,14 @@
-using Avalonia.ReactiveUI;
 using Microsoft.Extensions.DependencyInjection;
-using ReactiveUI;
+using SIT.Manager.Avalonia.Controls;
 using SIT.Manager.Avalonia.ViewModels;
 
 namespace SIT.Manager.Avalonia.Views;
 
-public partial class ModsPage : ReactiveUserControl<ModsPageViewModel>
+public partial class ModsPage : ActivatableUserControl
 {
     public ModsPage()
     {
-        this.DataContext = App.Current.Services.GetService<ModsPageViewModel>();
-        // ModsPageViewModel's WhenActivated block will also get called.
-        this.WhenActivated(disposables => { /* Handle view activation etc. */ });
+        DataContext = App.Current.Services.GetService<ModsPageViewModel>();
         InitializeComponent();
     }
 }

--- a/SIT.Manager.Avalonia/Views/ServerPage.axaml.cs
+++ b/SIT.Manager.Avalonia/Views/ServerPage.axaml.cs
@@ -1,13 +1,12 @@
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.ReactiveUI;
 using Microsoft.Extensions.DependencyInjection;
-using ReactiveUI;
+using SIT.Manager.Avalonia.Controls;
 using SIT.Manager.Avalonia.ViewModels;
 
 namespace SIT.Manager.Avalonia.Views;
 
-public partial class ServerPage : ReactiveUserControl<ServerPageViewModel>
+public partial class ServerPage : ActivatableUserControl
 {
     private bool _autoScroll = true;
     private readonly ScrollViewer? _consoleLogScroller;
@@ -18,9 +17,6 @@ public partial class ServerPage : ReactiveUserControl<ServerPageViewModel>
 
         InitializeComponent();
         _consoleLogScroller = this.FindControl<ScrollViewer>("ConsoleLogScroller");
-
-        // ServerPageViewModel's WhenActivated block will also get called.
-        this.WhenActivated(disposables => { /* Handle view activation etc. */ });
     }
 
     private void ConsoleLogScroller_ScrollChanged(object? sender, ScrollChangedEventArgs e)


### PR DESCRIPTION
A problem I kept running into while doing the new install page was the way view activation was triggered. So I removed the dependency on ReactiveUI as that was pretty much all we used it for and added a way to do it using just CommunityMVVM.

Surprisingly the only thing this broke was the settings button translation in the main view, so converted the settings button to be able to be translated in XAML. Haven't seen any other problems with this but let me know 😄 