### PR TITLE
Installation fixes

### DIFF
--- a/SIT.Manager/Extentions/HttpClientExtentions.cs
+++ b/SIT.Manager/Extentions/HttpClientExtentions.cs
@@ -13,18 +13,23 @@ internal static class HttpClientExtentions
 {
     public static async Task DownloadAsync(this HttpClient client, Stream destination, string url, IProgress<double> progressReporter, CancellationToken cancellationToken = default)
     {
-        using HttpResponseMessage response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        using HttpResponseMessage response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using Stream contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         long? contentLength = response.Content.Headers.ContentLength;
         if (!contentLength.HasValue)
         {
-            await contentStream.CopyToAsync(destination, cancellationToken);
+            await contentStream.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
         }
         else
         {
-            Progress<long> reportWrapper = new(br => progressReporter.Report((double) br / contentLength.Value));
-            await contentStream.CopyToAsync(destination, 65535, reportWrapper, cancellationToken);
+            double totalLength = contentLength.Value;
+            Progress<long> reportWrapper = new(br =>
+            {
+                double currentValue = br;
+                progressReporter.Report(currentValue / totalLength * 100);
+            });
+            await contentStream.CopyToAsync(destination, 65535, reportWrapper, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -365,7 +365,8 @@
 	<system:String x:Key="PatchViewDownloadingTitle">Downloading Patcher</system:String>
 	<system:String x:Key="PatchViewExtractingTitle">Extracting Patcher</system:String>
 	<system:String x:Key="PatchViewPatchingErrorMessage">Error trying to patch EFT consult the logs for details</system:String>
-	<system:String x:Key="PatchViewPatchingEndInstallButtonTitle">End Install</system:String>	
+	<system:String x:Key="PatchViewAquirePatcherErrorMessage">Error trying to aquire the patcher for EFT, please consult the logs for more details</system:String>
+	<system:String x:Key="PatchViewPatchingEndInstallButtonTitle">End Install</system:String>
 
 	<!-- Install - Select View -->
 	<system:String x:Key="SelectViewInstallServerButtonTitle">Install Server + SIT Mod</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -363,6 +363,7 @@
 	<system:String x:Key="PatchViewDownloadingTitle">Загрузка патчера</system:String>
 	<system:String x:Key="PatchViewExtractingTitle">Распаковка патчера</system:String>
 	<system:String x:Key="PatchViewPatchingErrorMessage">Ошибка при попытке патча EFT. Подробности смотрите в журналах</system:String>
+	<system:String x:Key="PatchViewAquirePatcherErrorMessage">Error trying to aquire the patcher for EFT, please consult the logs for more details</system:String>
 	<system:String x:Key="PatchViewPatchingEndInstallButtonTitle">Завершить установку</system:String>
 
 	<!-- Install - Select View -->

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -363,6 +363,7 @@
 	<system:String x:Key="PatchViewDownloadingTitle">Завантаження патчера</system:String>
 	<system:String x:Key="PatchViewExtractingTitle">Розпакування патчера</system:String>
 	<system:String x:Key="PatchViewPatchingErrorMessage">Помилка при спробі патчу EFT. Деталі дивіться у журналах</system:String>
+	<system:String x:Key="PatchViewAquirePatcherErrorMessage">Error trying to aquire the patcher for EFT, please consult the logs for more details</system:String>
 	<system:String x:Key="PatchViewPatchingEndInstallButtonTitle">Завершити установку</system:String>
 
 	<!-- Install - Select View -->

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -363,6 +363,7 @@
 	<system:String x:Key="PatchViewDownloadingTitle">正在下载补丁程序</system:String>
 	<system:String x:Key="PatchViewExtractingTitle">正在提取补丁程序</system:String>
 	<system:String x:Key="PatchViewPatchingErrorMessage">尝试对 EFT 进行修补时出错。请查看日志以获取详细信息</system:String>
+	<system:String x:Key="PatchViewAquirePatcherErrorMessage">Error trying to aquire the patcher for EFT, please consult the logs for more details</system:String>
 	<system:String x:Key="PatchViewPatchingEndInstallButtonTitle">完成安装</system:String>
 
 	<!-- Install - Select View -->

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -363,6 +363,7 @@
 	<system:String x:Key="PatchViewDownloadingTitle">正在下載補丁程序</system:String>
 	<system:String x:Key="PatchViewExtractingTitle">正在提取補丁程序</system:String>
 	<system:String x:Key="PatchViewPatchingErrorMessage">尝试对 EFT 进行修补时出错。请查看日志以获取详细信息</system:String>
+	<system:String x:Key="PatchViewAquirePatcherErrorMessage">Error trying to aquire the patcher for EFT, please consult the logs for more details</system:String>
 	<system:String x:Key="PatchViewPatchingEndInstallButtonTitle">完成安裝</system:String>
 
 	<!-- Install - Select View -->

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -363,6 +363,7 @@
 	<system:String x:Key="PatchViewDownloadingTitle">正在下載補丁</system:String>
 	<system:String x:Key="PatchViewExtractingTitle">正在解壓縮補丁</system:String>
 	<system:String x:Key="PatchViewPatchingErrorMessage">嘗試對 EFT 進行補丁時出錯。請查看日誌以獲取詳細信息</system:String>
+	<system:String x:Key="PatchViewAquirePatcherErrorMessage">Error trying to aquire the patcher for EFT, please consult the logs for more details</system:String>
 	<system:String x:Key="PatchViewPatchingEndInstallButtonTitle">完成安裝</system:String>
 
 	<!-- Install - Select View -->

--- a/SIT.Manager/Services/FileService.cs
+++ b/SIT.Manager/Services/FileService.cs
@@ -54,7 +54,7 @@ public class FileService(IActionNotificationService actionNotificationService,
         foreach (DirectoryInfo directory in directories)
         {
             DirectoryInfo newDestination = destination.CreateSubdirectory(directory.Name);
-            currentProgress = await CopyDirectoryAsync(directory, newDestination, currentProgress, totalSize, progress);
+            currentProgress = await CopyDirectoryAsync(directory, newDestination, currentProgress, totalSize, progress).ConfigureAwait(false);
         }
 
         foreach (FileInfo file in files)
@@ -68,7 +68,7 @@ public class FileService(IActionNotificationService actionNotificationService,
                         double progressPercentage = (currentProgress + x) / totalSize * 100;
                         progress?.Report(progressPercentage);
                     });
-                    await sourceStream.CopyToAsync(destinationStream, ushort.MaxValue, streamProgress);
+                    await sourceStream.CopyToAsync(destinationStream, ushort.MaxValue, streamProgress).ConfigureAwait(false);
                     currentProgress += file.Length;
                 }
             }

--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -125,7 +125,7 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
         {
             releasesJsonString = await GetHttpStringWithRetryAsync(() => _httpClient.GetStringAsync(@"https://patcher.stayintarkov.com/api/v1/repos/SIT/Downgrade-Patches/releases"), TimeSpan.FromSeconds(1), 3);
         }
-        catch(AuthenticationException)
+        catch (AuthenticationException)
         {
             await blockedByISPWarning.ShowAsync();
             return [];
@@ -136,7 +136,7 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
         {
             giteaReleases = JsonSerializer.Deserialize<List<GiteaRelease>>(releasesJsonString) ?? [];
         }
-        catch(JsonException)
+        catch (JsonException)
         {
             await blockedByISPWarning.ShowAsync();
             return [];
@@ -503,7 +503,7 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
                 }
                 return false;
             }).ToList();
-            updateAvailable = _availableSitUpdateVersions.Any();
+            updateAvailable = _availableSitUpdateVersions.Count != 0;
         }
 
         return updateAvailable;

--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -650,7 +650,7 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
             {
                 internalDownloadProgress = new(progress =>
                 {
-                    internalDownloadProgressPercentage = 0.5 + (progress / downloadAndExtractionSteps);
+                    internalDownloadProgressPercentage = 50 + (progress / downloadAndExtractionSteps);
                     downloadProgress.Report(internalDownloadProgressPercentage);
                 });
                 internalExtractionProgress = new(progress =>

--- a/SIT.Manager/Services/PickerDialogService.cs
+++ b/SIT.Manager/Services/PickerDialogService.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using SIT.Manager.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -17,14 +18,21 @@ public class PickerDialogService : IPickerDialogService
 
     public async Task<IStorageFolder?> GetDirectoryFromPickerAsync()
     {
-        IReadOnlyList<IStorageFolder> folders = await _target.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions()
+        try
         {
-            AllowMultiple = false
-        });
+            IReadOnlyList<IStorageFolder> folders = await _target.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions()
+            {
+                AllowMultiple = false
+            });
 
-        if (folders.Count != 0)
+            if (folders.Count != 0)
+            {
+                return folders[0];
+            }
+        }
+        catch (ArgumentException)
         {
-            return folders[0];
+            // The likely reason is the folder selected doesn't exist so we should just be able to return null as with other things.
         }
         return null;
     }

--- a/SIT.Manager/ViewModels/Installation/ConfigureServerViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/ConfigureServerViewModel.cs
@@ -87,16 +87,19 @@ public partial class ConfigureServerViewModel : InstallationViewModelBase
 
     private void ValidateConfiguration()
     {
+        IsConfigurationValid = true;
+
         if (string.IsNullOrEmpty(CurrentInstallProcessState.SptAkiInstallPath))
         {
             IsConfigurationValid = false;
             return;
         }
-        if (SelectedVersion == null)
+
+        if (SelectedVersion == null || AvailableVersions.Count == 0)
         {
             IsConfigurationValid = false;
+            return;
         }
-        IsConfigurationValid = true;
     }
 
     protected override async void OnActivated()

--- a/SIT.Manager/ViewModels/Installation/InstallViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/InstallViewModel.cs
@@ -36,8 +36,7 @@ public partial class InstallViewModel : InstallationViewModelBase
 
     private void DownloadProgress_ProgressChanged(object? sender, double e)
     {
-        // For some reason this is 100 times smaller than expected so just x100 I guess?
-        DownloadProgressPercentage = e * 100;
+        DownloadProgressPercentage = e;
         UpdateInstallProgress();
     }
 

--- a/SIT.Manager/ViewModels/Installation/PatchViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/PatchViewModel.cs
@@ -29,9 +29,9 @@ public partial class PatchViewModel : InstallationViewModelBase
         { 15, "Patcher failed." }
     };
 
-    private readonly Progress<double> _copyProgress = new();
-    private readonly Progress<double> _downloadProgress = new();
-    private readonly Progress<double> _extractionProgress = new();
+    private readonly Progress<double> _copyProgress;
+    private readonly Progress<double> _downloadProgress;
+    private readonly Progress<double> _extractionProgress;
 
     [ObservableProperty]
     private double _copyProgressPercentage = 0;
@@ -66,33 +66,9 @@ public partial class PatchViewModel : InstallationViewModelBase
 
         RequiresPatching = !string.IsNullOrEmpty(CurrentInstallProcessState.DownloadMirrorUrl);
 
-        _copyProgress.ProgressChanged += CopyProgress_ProgressChanged;
-        _downloadProgress.ProgressChanged += DownloadProgress_ProgressChanged;
-        _extractionProgress.ProgressChanged += ExtractionProgress_ProgressChanged;
-    }
-
-    private void CopyProgress_ProgressChanged(object? sender, double e)
-    {
-        CopyProgressPercentage = e;
-    }
-
-    private void DownloadProgress_ProgressChanged(object? sender, double e)
-    {
-        // The normal download is 100x smaller than the mega api client outputs
-        // so we have to manually adjust it here (head -> wall)
-        if (CurrentInstallProcessState.DownloadMirrorUrl.Contains("mega.nz"))
-        {
-            DownloadProgressPercentage = e;
-        }
-        else
-        {
-            DownloadProgressPercentage = e * 100;
-        }
-    }
-
-    private void ExtractionProgress_ProgressChanged(object? sender, double e)
-    {
-        ExtractionProgressPercentage = e;
+        _copyProgress = new(x => CopyProgressPercentage = x);
+        _downloadProgress = new(x => DownloadProgressPercentage = x);
+        _extractionProgress = new(x => ExtractionProgressPercentage = x);
     }
 
     private async Task RunPatcher()

--- a/SIT.Manager/ViewModels/Installation/PatchViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/PatchViewModel.cs
@@ -71,7 +71,16 @@ public partial class PatchViewModel : InstallationViewModelBase
 
     private void DownloadProgress_ProgressChanged(object? sender, double e)
     {
+        // The normal download is 100x smaller than the mega api client outputs
+        // so we have to manually adjust it here (head -> wall)
+        if (CurrentInstallProcessState.DownloadMirrorUrl.Contains("mega.nz"))
+        {
+            DownloadProgressPercentage = e;
+        }
+        else
+        {
         DownloadProgressPercentage = e * 100;
+    }
     }
 
     private void ExtractionProgress_ProgressChanged(object? sender, double e)

--- a/SIT.Manager/ViewModels/Installation/PatchViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/PatchViewModel.cs
@@ -117,7 +117,7 @@ public partial class PatchViewModel : InstallationViewModelBase
         }
 
         _patcherResultMessages.TryGetValue(embeddedProcessWindow.ExitCode, out string? patcherResult);
-        _logger.LogInformation($"RunPatcher: {patcherResult}");
+        _logger.LogInformation("RunPatcher: {patcherResult}", patcherResult);
 
         int exitCode = embeddedProcessWindow.ExitCode;
         EmbeddedPatcherWindow = null;

--- a/SIT.Manager/ViewModels/UpdatePageViewModel.cs
+++ b/SIT.Manager/ViewModels/UpdatePageViewModel.cs
@@ -29,7 +29,7 @@ public partial class UpdatePageViewModel : ObservableObject
         _appUpdaterService = appUpdaterService;
         _localizationService = localizationService;
 
-        _updateProgress = new Progress<double>(prog => UpdateProgressPercentage = prog * 100);
+        _updateProgress = new Progress<double>(prog => UpdateProgressPercentage = prog);
 
         UpdateManagerCommand = new AsyncRelayCommand(UpdateManager);
     }

--- a/SIT.Manager/Views/Installation/PatchView.axaml
+++ b/SIT.Manager/Views/Installation/PatchView.axaml
@@ -99,10 +99,14 @@
 			<Grid ColumnDefinitions="*" RowDefinitions="*">
 				<ContentControl Content="{Binding EmbeddedPatcherWindow}"/>
 
-				<StackPanel IsVisible="{Binding HasPatcherError}"
+				<StackPanel IsVisible="{Binding HasError}"
 							HorizontalAlignment="Center"
 							VerticalAlignment="Center">
-					<TextBlock Classes="ErrorMessage" 
+					<TextBlock Classes="ErrorMessage"
+							   IsVisible="{Binding HasAquirePatcherError}"
+							   Text="{DynamicResource PatchViewAquirePatcherErrorMessage}"/>
+					<TextBlock Classes="ErrorMessage"
+							   IsVisible="{Binding HasPatcherError}"
 							   Text="{DynamicResource PatchViewPatchingErrorMessage}"/>
 					<Button Command="{Binding EndInstallCommand}"
 							HorizontalAlignment="Center"


### PR DESCRIPTION
Fix and improve a few things for installation.

1. Should resolve #129 as the normal downloading value we get is between 0 and 1 but for mega downloads is between 0 and 100, maybe we need to fix the actual root cause which I think is in [HttpClientExtentions.cs](https://github.com/stayintarkov/SIT.Manager.Avalonia/blob/master/SIT.Manager/Extentions/HttpClientExtentions.cs) although we'd then have to go find all the other places we account for this.
2. Should resolve #141 I'm not quite sure who's at fault for this as it was the actual file picker from Avalonia which we use throws an Argument Exception if you try and select a directory which doesn't exist, I kind of assumed it just returned null. So now if you do that the manager won't crash.
3. Make downloads from Mega actually use the file path it's supposed to rather than the one selected from the manger config as they won't always align now.
4. If the Manager fails to download the downgrade patcher this should be displayed properly now rather than locking the user out with no feedback.
5. You also won't be able to attempt to install the server if there is no version available to actually install