### PR TITLE
Concurrency and Game Copy Validation

### DIFF
--- a/SIT.Manager/Interfaces/IFileService.cs
+++ b/SIT.Manager/Interfaces/IFileService.cs
@@ -5,7 +5,7 @@ namespace SIT.Manager.Services;
 
 public interface IFileService
 {
-    Task CopyDirectory(string source, string destination, IProgress<double>? progress = null);
+    Task CopyAndValidateDirectory(string source, string destination, IProgress<double>? progress = null);
     /// <summary>
     /// Downloads a file and report progress if enabled
     /// </summary>

--- a/SIT.Manager/ViewModels/Installation/PatchViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/PatchViewModel.cs
@@ -75,7 +75,7 @@ public partial class PatchViewModel : InstallationViewModelBase
     {
         if (CurrentInstallProcessState.UsingBsgInstallPath)
         {
-            await _fileService.CopyDirectory(CurrentInstallProcessState.BsgInstallPath, CurrentInstallProcessState.EftInstallPath, _copyProgress);
+            await _fileService.CopyAndValidateDirectory(CurrentInstallProcessState.BsgInstallPath, CurrentInstallProcessState.EftInstallPath, _copyProgress);
         }
     }
 

--- a/SIT.Manager/Views/Installation/PatchView.axaml
+++ b/SIT.Manager/Views/Installation/PatchView.axaml
@@ -108,7 +108,7 @@
 					<TextBlock Classes="ErrorMessage"
 							   IsVisible="{Binding HasPatcherError}"
 							   Text="{DynamicResource PatchViewPatchingErrorMessage}"/>
-					<Button Command="{Binding EndInstallCommand}"
+					<Button Command="{Binding FinishInstallCommand}"
 							HorizontalAlignment="Center"
 							Margin="8"
 							Content="{DynamicResource PatchViewPatchingEndInstallButtonTitle}"/>


### PR DESCRIPTION
Not sure how well this is actually working so am open to opinions on this.

Should make the download and extraction for the patcher run at the same time as copying the EFT directory if either are required. Will also ensure validate that any eft files already copied are correct so that it won't copy if they aren't required.

From testing however this seems to run a lot slower than it did before so I might be being quite stupid in what/how I've done things.