### PR TITLE
Allow users to use default mirror on download

### DIFF
--- a/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
@@ -138,6 +138,10 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
         // TODO add some logging here and an alert somehow in case it fails to load any versions or something
 
         IsVersionSelectionLoading = false;
+        
+        // Validate the configuration to allow the user to start the installation without having to change the mirror
+        // This way the user is able to use the first available mirror without having to change it
+        ValidateConfiguration();
     }
 
     [RelayCommand]


### PR DESCRIPTION
Added a simple ValidateConfiguration call at the end of FetchVersionAndMirrorMatrix because it was bugging me :)
This now allows users to simply click next on the install instead of having to change mirror (even if the mirror they want to use is selected).