### PR TITLE
Ensure only one draft of release gets created

### DIFF
--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      Solution_Name: SIT.Manager.sln
+      DeploymentDirectory: deployment
 
     steps:
     - name: Checkout
@@ -59,18 +59,53 @@ jobs:
         VersionString=`strings ${{ github.workspace }}/SIT.Manager.Desktop/bin/Release/net8.0/${{ matrix.os }}/publish/SIT.Manager.exe | egrep -m 1 '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'`
         echo "RELEASE_VERSION=$VersionString" >> "$GITHUB_ENV"
 
-    - name: Output Release Tag
+    - name: Output Release Version
       id: tag
       run: |
           TAG=$RELEASE_VERSION
           echo "$TAG"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-
-    # Create release as draft from the compressed output
-    - name: Create Release
-      uses: softprops/action-gh-release@v2
+          echo "MANAGER_VERSION=$TAG" >> $GITHUB_OUTPUT
+          
+    - name: Upload Artifact
+      id: artifact-upload
+      uses: actions/upload-artifact@v4
       with:
+        name: ${{ matrix.os }}
+        path: ${{ env.DeploymentDirectory }}
+          
+    - name: Output Artifact
+      run: echo "${{ matrix.platform }}=${{ steps.artifact-upload.outputs.download-url }}" >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get Windows Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: win-x64
+          path: win_extracted
+
+      - name: Get Linux Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-x64
+          path: linux_extracted
+
+      - name: Tar Linux Artifact
+        run: find linux_extracted -printf "%P\n" | tar -czf linux-x64.tar.gz --no-recursion -C linux_extracted -T -
+
+      - name: Zip Windows Artifact
+        run: (cd win_extracted && zip -r ../win-x64.zip . && cd ..)
+
+      - name: Generate Release Draft
+        uses: softprops/action-gh-release@v2
+        with:
           draft: true
           generate_release_notes: true
-          files: ${{ github.workspace }}/SIT.Manager.Desktop/bin/Release/net8.0/${{ matrix.os }}/publish/${{ matrix.os }}.*
-          tag_name: ${{ steps.tag.outputs.tag }}
+          files: |
+            win-x64.zip
+            linux-x64.tar.gz
+          tag_name: ${{ needs.build.outputs.MANAGER_VERSION }}

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -41,9 +41,8 @@ jobs:
       with:
         name: ${{ matrix.os }}
         path: ${{ env.DeploymentDirectory }}
-          
-    - name: Output Artifact
-      run: echo "${{ matrix.os }}=${{ steps.artifact-upload.outputs.download-url }}" >> "$GITHUB_OUTPUT"
+        if-no-files-found: error
+        retention-days: 3
 
   release:
     needs: build

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -33,7 +33,7 @@ jobs:
         Write-Output "VERSION=$BuildTime" >> $env:GITHUB_OUTPUT 
         
     - name: Build Published Version
-      run: dotnet publish SIT.Manager.Desktop/SIT.Manager.Desktop.csproj -c Release -r ${{ matrix.os }} -p:BuildNumber=${{ steps.build.outputs.NOW }} -p:RevisionNumber=${{ steps.build.outputs.VERSION }}
+      run: dotnet publish SIT.Manager.Desktop/SIT.Manager.Desktop.csproj -c Release -r ${{ matrix.os }} -p:BuildNumber=${{ steps.build.outputs.NOW }} -p:RevisionNumber=${{ steps.build.outputs.VERSION }} -o ${{ env.DeploymentDirectory }}
 
     # Compress the published output for both Windows and Linux
     - name: Compress on Linux

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -35,37 +35,6 @@ jobs:
     - name: Build Published Version
       run: dotnet publish SIT.Manager.Desktop/SIT.Manager.Desktop.csproj -c Release -r ${{ matrix.os }} -p:BuildNumber=${{ steps.build.outputs.NOW }} -p:RevisionNumber=${{ steps.build.outputs.VERSION }} -o ${{ env.DeploymentDirectory }}
 
-    # Compress the published output for both Windows and Linux
-    - name: Compress on Linux
-      if: ${{ matrix.os == 'linux-x64' }}
-      run: |
-        cd ${{ env.DeploymentDirectory }}
-        tar -czvf ${{ matrix.os }}.tar.gz *
-    - name: Compress on Windows
-      if: ${{ matrix.os == 'win-x64' }}
-      run: |
-        cd ${{ env.DeploymentDirectory }}
-        zip -r ${{ matrix.os }}.zip * 
-
-    # Get the build version for both Windows and Linux
-    - name: Get Release Version
-      if: ${{ matrix.os == 'linux-x64' }}
-      run: |
-        VersionString=`strings ${{ env.DeploymentDirectory }}/SIT.Manager | egrep -m 1 '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'`
-        echo "RELEASE_VERSION=$VersionString" >> "$GITHUB_ENV"
-    - name: Get Release Version
-      if: ${{ matrix.os == 'win-x64' }}
-      run: |
-        VersionString=`strings ${{ env.DeploymentDirectory }}/SIT.Manager.exe | egrep -m 1 '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'`
-        echo "RELEASE_VERSION=$VersionString" >> "$GITHUB_ENV"
-
-    - name: Output Release Version
-      id: tag
-      run: |
-          TAG=$RELEASE_VERSION
-          echo "$TAG"
-          echo "MANAGER_VERSION=$TAG" >> $GITHUB_OUTPUT
-          
     - name: Upload Artifact
       id: artifact-upload
       uses: actions/upload-artifact@v4
@@ -95,11 +64,24 @@ jobs:
           path: linux_extracted
 
       - name: Tar Linux Artifact
-        run: find linux_extracted -printf "%P\n" | tar -czf linux-x64.tar.gz --no-recursion -C linux_extracted -T -
+        run: |
+          cd linux_extracted
+          tar -czvf linux-x64.tar.gz -C ../linux_extracted *
+          cd ..
 
       - name: Zip Windows Artifact
-        run: (cd win_extracted && zip -r ../win-x64.zip . && cd ..)
+        run: |
+          cd win_extracted
+          zip -r ../win-x64.zip *
+          cd ..
 
+     # Get the build version for tagging the release
+      - name: Get Release Version
+        id: tag
+        run: |
+          VersionString=`strings win_extracted/SIT.Manager.exe | egrep -m 1 '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'`
+          echo "MANAGER_VERSION=$VersionString" >> $GITHUB_OUTPUT
+                              
       - name: Generate Release Draft
         uses: softprops/action-gh-release@v2
         with:
@@ -108,4 +90,4 @@ jobs:
           files: |
             win-x64.zip
             linux-x64.tar.gz
-          tag_name: ${{ needs.build.outputs.MANAGER_VERSION }}
+          tag_name: ${{ steps.tag.outputs.MANAGER_VERSION }}

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -64,10 +64,7 @@ jobs:
           path: linux_extracted
 
       - name: Tar Linux Artifact
-        run: |
-          cd linux_extracted
-          tar -czvf linux-x64.tar.gz -C ../linux_extracted *
-          cd ..
+        run: find linux_extracted -printf "%P\n" | tar -czf linux-x64.tar.gz --no-recursion -C linux_extracted -T -
 
       - name: Zip Windows Artifact
         run: |

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -39,24 +39,24 @@ jobs:
     - name: Compress on Linux
       if: ${{ matrix.os == 'linux-x64' }}
       run: |
-        cd ${{ github.workspace }}/SIT.Manager.Desktop/bin/Release/net8.0/${{ matrix.os }}/publish/
+        cd ${{ env.DeploymentDirectory }}
         tar -czvf ${{ matrix.os }}.tar.gz *
     - name: Compress on Windows
       if: ${{ matrix.os == 'win-x64' }}
       run: |
-        cd ${{ github.workspace }}/SIT.Manager.Desktop/bin/Release/net8.0/${{ matrix.os }}/publish/
+        cd ${{ env.DeploymentDirectory }}
         zip -r ${{ matrix.os }}.zip * 
 
     # Get the build version for both Windows and Linux
     - name: Get Release Version
       if: ${{ matrix.os == 'linux-x64' }}
       run: |
-        VersionString=`strings ${{ github.workspace }}/SIT.Manager.Desktop/bin/Release/net8.0/${{ matrix.os }}/publish/SIT.Manager | egrep -m 1 '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'`
+        VersionString=`strings ${{ env.DeploymentDirectory }}/SIT.Manager | egrep -m 1 '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'`
         echo "RELEASE_VERSION=$VersionString" >> "$GITHUB_ENV"
     - name: Get Release Version
       if: ${{ matrix.os == 'win-x64' }}
       run: |
-        VersionString=`strings ${{ github.workspace }}/SIT.Manager.Desktop/bin/Release/net8.0/${{ matrix.os }}/publish/SIT.Manager.exe | egrep -m 1 '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'`
+        VersionString=`strings ${{ env.DeploymentDirectory }}/SIT.Manager.exe | egrep -m 1 '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'`
         echo "RELEASE_VERSION=$VersionString" >> "$GITHUB_ENV"
 
     - name: Output Release Version

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -74,7 +74,7 @@ jobs:
         path: ${{ env.DeploymentDirectory }}
           
     - name: Output Artifact
-      run: echo "${{ matrix.platform }}=${{ steps.artifact-upload.outputs.download-url }}" >> "$GITHUB_OUTPUT"
+      run: echo "${{ matrix.os }}=${{ steps.artifact-upload.outputs.download-url }}" >> "$GITHUB_OUTPUT"
 
   release:
     needs: build


### PR DESCRIPTION
Should ensure that only one release draft ever gets created by putting the release creation into a seperate job.