### PR TITLE
Properly fix configmanager installation

### DIFF
--- a/SIT.Manager/Services/ModService.cs
+++ b/SIT.Manager/Services/ModService.cs
@@ -37,11 +37,13 @@ public class ModService(IBarNotificationService barNotificationService,
 
     private async Task InstallFiles(string baseSourceDirectory, string baseTargetDirectory, List<string> files)
     {
+        // Ensure that the directory that we are trying to copy to exists
+        Directory.CreateDirectory(baseTargetDirectory);
+
         foreach (string file in files)
         {
             string sourcePath = Path.Combine(baseSourceDirectory, file);
             string targetPath = Path.Combine(baseTargetDirectory, file);
-            Directory.CreateDirectory(targetPath);
             await _filesService.CopyFileAsync(sourcePath, targetPath).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
Create the directory that it should rather than creating a directory of the filename

Currently creates the directory below rather than just ensuring that the one it's trying to copy to exists:
![image](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/112902041/c6485c50-ca21-4a37-91f4-002801b7f344)
