### PR TITLE
Caching in some places

### DIFF
--- a/SIT.Manager/Models/ManagerConfig.cs
+++ b/SIT.Manager/Models/ManagerConfig.cs
@@ -41,6 +41,8 @@ public partial class ManagerConfig : ObservableObject
     [ObservableProperty]
     public bool _lookForUpdates = true;
     [ObservableProperty]
+    private DateTime _lastManagerUpdateCheckTime = DateTime.MinValue;
+    [ObservableProperty]
     public string _currentLanguageSelected = CultureInfo.CurrentCulture.Name;
     [ObservableProperty]
     public bool _hideIpAddress = true;

--- a/SIT.Manager/Models/ManagerConfig.cs
+++ b/SIT.Manager/Models/ManagerConfig.cs
@@ -33,7 +33,7 @@ public partial class ManagerConfig : ObservableObject
     [ObservableProperty]
     public string _sitVersion = string.Empty;
     [ObservableProperty]
-    private DateTime _lastSitUpdateCheckTime = DateTime.MinValue;
+    private DateTime _lastSitUpdateCheckTime = DateTime.MaxValue;
     [ObservableProperty]
     public string _sptAkiVersion = string.Empty;
     [ObservableProperty]
@@ -41,7 +41,7 @@ public partial class ManagerConfig : ObservableObject
     [ObservableProperty]
     public bool _lookForUpdates = true;
     [ObservableProperty]
-    private DateTime _lastManagerUpdateCheckTime = DateTime.MinValue;
+    private DateTime _lastManagerUpdateCheckTime = DateTime.MaxValue;
     [ObservableProperty]
     public string _currentLanguageSelected = CultureInfo.CurrentCulture.Name;
     [ObservableProperty]

--- a/SIT.Manager/Services/AppUpdaterService.cs
+++ b/SIT.Manager/Services/AppUpdaterService.cs
@@ -100,7 +100,7 @@ public class AppUpdaterService(IFileService fileService, ILogger<AppUpdaterServi
         Version currentVersion = Assembly.GetEntryAssembly()?.GetName().Version ?? new Version("0");
         Version latestVersion = new();
 
-        if (_managerConfigService.Config.LookForUpdates && DateTime.Now.AddHours(-1) > _managerConfigService.Config.LastManagerUpdateCheckTime)
+        if (_managerConfigService.Config.LookForUpdates && DateTime.Now.AddHours(-1) < _managerConfigService.Config.LastManagerUpdateCheckTime)
         {
             try
             {

--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -502,7 +502,7 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
             return false;
         }
 
-        if (DateTime.Now.AddHours(-1) > _configService.Config.LastSitUpdateCheckTime)
+        if (DateTime.Now.AddHours(-1) < _configService.Config.LastSitUpdateCheckTime)
         {
             // We haven't checked for updates in the last hour so refresh the available verisons
             _availableSitUpdateVersions = await GetAvailableSitReleases(_configService.Config.TarkovVersion);

--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -502,7 +502,7 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
             return false;
         }
 
-        if (DateTime.Now.AddHours(-1) < _configService.Config.LastSitUpdateCheckTime)
+        if (DateTime.Now.AddHours(-1) > _configService.Config.LastSitUpdateCheckTime)
         {
             // We haven't checked for updates in the last hour so refresh the available verisons
             _availableSitUpdateVersions = await GetAvailableSitReleases(_configService.Config.TarkovVersion);

--- a/SIT.Manager/Services/ManagerConfigService.cs
+++ b/SIT.Manager/Services/ManagerConfigService.cs
@@ -12,6 +12,14 @@ internal sealed class ManagerConfigService : IManagerConfigService
 {
     private readonly ILogger<ManagerConfigService> _logger;
 
+    private readonly JsonSerializerOptions _jsonSerializationOptions = new()
+    {
+        Converters = {
+            new ColorJsonConverter()
+        },
+        WriteIndented = true
+    };
+
     private ManagerConfig _config = new();
     public ManagerConfig Config
     {
@@ -29,20 +37,13 @@ internal sealed class ManagerConfigService : IManagerConfigService
 
     private void Load()
     {
-        var options = new JsonSerializerOptions()
-        {
-            Converters = {
-                new ColorJsonConverter()
-            }
-        };
-
         try
         {
             string managerConfigPath = Path.Combine(AppContext.BaseDirectory, "ManagerConfig.json");
             if (File.Exists(managerConfigPath))
             {
                 string json = File.ReadAllText(managerConfigPath);
-                _config = JsonSerializer.Deserialize<ManagerConfig>(json, options) ?? new();
+                _config = JsonSerializer.Deserialize<ManagerConfig>(json, _jsonSerializationOptions) ?? new();
             }
         }
         catch (Exception ex)
@@ -57,14 +58,6 @@ internal sealed class ManagerConfigService : IManagerConfigService
         _config = config;
         SaveAccount ??= config.RememberLogin;
 
-        var options = new JsonSerializerOptions()
-        {
-            Converters = {
-                new ColorJsonConverter()
-            },
-            WriteIndented = true
-        };
-
         if (ShouldSave)
         {
             ManagerConfig newLauncherConfig = _config;
@@ -75,7 +68,7 @@ internal sealed class ManagerConfigService : IManagerConfigService
             }
 
             string managerConfigPath = Path.Combine(AppContext.BaseDirectory, "ManagerConfig.json");
-            File.WriteAllText(managerConfigPath, JsonSerializer.Serialize(newLauncherConfig, options));
+            File.WriteAllText(managerConfigPath, JsonSerializer.Serialize(newLauncherConfig, _jsonSerializationOptions));
         }
 
         ConfigChanged?.Invoke(this, _config);

--- a/SIT.Manager/ViewModels/ServerPageViewModel.cs
+++ b/SIT.Manager/ViewModels/ServerPageViewModel.cs
@@ -27,9 +27,10 @@ public partial class ServerPageViewModel : ObservableRecipient
 
     private readonly IAkiServerService _akiServerService;
     private readonly IManagerConfigService _configService;
-    private FontFamily cachedFontFamily = FontFamily.Parse("Bender");
-    private SolidColorBrush cachedColorBrush = new(Color.FromRgb(255, 255, 255));
     private readonly IFileService _fileService;
+
+    private readonly SolidColorBrush cachedColorBrush = new(Color.FromRgb(255, 255, 255));
+    private FontFamily cachedFontFamily = FontFamily.Parse("Bender");
 
     [ObservableProperty]
     private Symbol _startServerButtonSymbolIcon = Symbol.Play;
@@ -54,11 +55,6 @@ public partial class ServerPageViewModel : ObservableRecipient
         StartServerButtonTextBlock = _localizationService.TranslateSource("ServerPageViewModelStartServer");
         EditServerConfigCommand = new AsyncRelayCommand(EditServerConfig);
         ClearServerOutputCommand = new AsyncRelayCommand(ClearServerOutput);
-
-        configService.ConfigChanged += (o, e) =>
-        {
-            StartServerButtonTextBlock = _localizationService.TranslateSource("ServerPageViewModelStartServer");
-        };
     }
 
     private async Task ClearServerOutput()
@@ -79,6 +75,8 @@ public partial class ServerPageViewModel : ObservableRecipient
 
     private void UpdateCachedServerProperties(object? sender, ManagerConfig newConfig)
     {
+        StartServerButtonTextBlock = _localizationService.TranslateSource("ServerPageViewModelStartServer");
+
         FontFamily newFont = FontManager.Current.SystemFonts.FirstOrDefault(x => x.Name == newConfig.ConsoleFontFamily, FontFamily.Parse("Bender"));
         if (!newFont.Name.Equals(cachedFontFamily.Name))
         {
@@ -89,7 +87,10 @@ public partial class ServerPageViewModel : ObservableRecipient
             }
         }
 
-        cachedColorBrush.Color = newConfig.ConsoleFontColor;
+        if (newConfig.ConsoleFontColor != cachedColorBrush.Color)
+        {
+            Dispatcher.UIThread.Post(() => cachedColorBrush.Color = newConfig.ConsoleFontColor);
+        }
     }
 
     private void UpdateConsoleWithCachedEntries()
@@ -223,8 +224,6 @@ public partial class ServerPageViewModel : ObservableRecipient
 
     protected override void OnActivated()
     {
-        UpdateCachedServerProperties(null, _configService.Config);
-        _configService.ConfigChanged += UpdateCachedServerProperties;
         if (_akiServerService.State != RunningState.NotRunning)
         {
             AkiServer_RunningStateChanged(null, _akiServerService.State);
@@ -232,13 +231,17 @@ public partial class ServerPageViewModel : ObservableRecipient
 
         _akiServerService.OutputDataReceived += AkiServer_OutputDataReceived;
         _akiServerService.RunningStateChanged += AkiServer_RunningStateChanged;
+        _configService.ConfigChanged += UpdateCachedServerProperties;
 
+        UpdateCachedServerProperties(null, _configService.Config);
         UpdateConsoleWithCachedEntries();
     }
 
     protected override void OnDeactivated()
     {
+        // We don't want these event firing when the page isn't currently active.
         _akiServerService.OutputDataReceived -= AkiServer_OutputDataReceived;
         _akiServerService.RunningStateChanged -= AkiServer_RunningStateChanged;
+        _configService.ConfigChanged -= UpdateCachedServerProperties;
     }
 }


### PR DESCRIPTION
Wrapped up a couple of things into this

1. Cache the last check time for manager update checking and only do this once an hour. Does potentially mean a user could start the manager get told there is an update, restart the manager and then not get told about the update at the moment but will dramatically reduce the amount of usage of the api. However might mean we want a button somewhere that forces a check or something?
2. Fix the SIT update check so that it actually will check for an update now.
3. Cache the json serializer options for the manager config as we use them a lot so no need to recreate it constantly.
4. Should hopefully fix the weird issue I saw earlier when trying to install mods.