### PR TITLE
Supress compatibility warning on install for recommended SIT mods

### DIFF
--- a/SIT.Manager/Interfaces/IModService.cs
+++ b/SIT.Manager/Interfaces/IModService.cs
@@ -35,8 +35,9 @@ public interface IModService
     /// <param name="targetPath">Base location of where the EFT install is to put the mod</param>
     /// <param name="mod">The meta data for the mod we want to install</param>
     /// <param name="suppressNotification">Supress notifications of the mods installation status</param>
+    /// <param name="suppressCompatibilityWarning">Supress the warning about a mods compatibility</param>
     /// <returns></returns>
-    Task<bool> InstallMod(string targetPath, ModInfo mod, bool suppressNotification = false);
+    Task<bool> InstallMod(string targetPath, ModInfo mod, bool suppressNotification = false, bool suppressCompatibilityWarning = false);
     /// <summary>
     /// Load the master list of mods into memory so we know what mods are available
     /// </summary>

--- a/SIT.Manager/Services/ModService.cs
+++ b/SIT.Manager/Services/ModService.cs
@@ -139,7 +139,7 @@ public class ModService(IBarNotificationService barNotificationService,
         _barNotificationService.ShowSuccess(_localizationService.TranslateSource("ModServiceUpdatedModsTitle"), _localizationService.TranslateSource("ModServiceUpdatedModsDescription", $"{outdatedMods.Count}"));
     }
 
-    public async Task<bool> InstallMod(string targetPath, ModInfo mod, bool suppressNotification = false)
+    public async Task<bool> InstallMod(string targetPath, ModInfo mod, bool suppressNotification = false, bool suppressCompatibilityWarning = false)
     {
         if (string.IsNullOrEmpty(targetPath))
         {
@@ -149,7 +149,7 @@ public class ModService(IBarNotificationService barNotificationService,
 
         try
         {
-            if (mod.SupportedVersion != _configService.Config.SitVersion)
+            if (mod.SupportedVersion != _configService.Config.SitVersion && !suppressCompatibilityWarning)
             {
                 ContentDialog contentDialog = new()
                 {

--- a/SIT.Manager/ViewModels/Installation/InstallViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/InstallViewModel.cs
@@ -115,7 +115,7 @@ public partial class InstallViewModel : InstallationViewModelBase
 
         foreach (ModInfo mod in CurrentInstallProcessState.RequestedMods)
         {
-            await _modService.InstallMod(CurrentInstallProcessState.EftInstallPath, mod, true);
+            await _modService.InstallMod(CurrentInstallProcessState.EftInstallPath, mod, true, true);
 
             // We copied settings so remove a step and force a progress bar recalculation
             _installSteps--;


### PR DESCRIPTION
I think this should help clear up some of the confusion some people have by suppressing the compatibility warning on installing the Configuration manager with a default SIT install, as we are doing the installing for them I think this makes sense that we just do it without having the dialog pop up..