### PR TITLE
Prevent crash on launching with no internet

### DIFF
--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -504,4 +504,8 @@
 	<system:String x:Key="DirectConnectViewModelAccountNotFoundDescription">Your account has not been found, would you like to register a new account with these credentials?</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonYes">Yes</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonNo">No</system:String>
+
+	<!-- MainViewModel -->
+	<system:String x:Key="MainViewModelUpdateErrorTitle">Error</system:String>
+	<system:String x:Key="MainViewModelUpdateErrorMessage">Failed when checking for updates</system:String>
 </ResourceDictionary>

--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -339,6 +339,7 @@
 	<system:String x:Key="ConfigureViewPersonalizationOptions">Personalization and Import Options</system:String>
 	
 	<!-- Install - Configure Server View -->
+	<system:String x:Key="ConfigureServerViewVersionSelectionErrorMessage">Unable to determine available SIT Server versions...</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathToolTip">Change the SPT-AKI Install Path.</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathTitle">Change</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathPlaceholder">SPT-AKI Install Path...</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -344,6 +344,7 @@
 	<system:String x:Key="ConfigureViewPersonalizationOptions">Персонализация и варианты импорта</system:String>
 
 	<!-- Install - Configure Server View -->
+	<system:String x:Key="ConfigureServerViewVersionSelectionErrorMessage">Unable to determine available SIT Server versions...</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathToolTip">Изменить путь установки SPT-AKI.</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathTitle">Изменить</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathPlaceholder">Путь установки SPT-AKI...</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -507,4 +507,8 @@
 	<system:String x:Key="DirectConnectViewModelAccountNotFoundDescription">Your account has not been found, would you like to register a new account with these credentials?</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonYes">Yes</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonNo">No</system:String>
+
+	<!-- MainViewModel -->
+	<system:String x:Key="MainViewModelUpdateErrorTitle">Error</system:String>
+	<system:String x:Key="MainViewModelUpdateErrorMessage">Failed when checking for updates</system:String>
 </ResourceDictionary>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -344,6 +344,7 @@
 	<system:String x:Key="ConfigureViewPersonalizationOptions">Персоналізація та Імпорт Налаштувань</system:String>
 
 	<!-- Install - Configure Server View -->
+	<system:String x:Key="ConfigureServerViewVersionSelectionErrorMessage">Unable to determine available SIT Server versions...</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathToolTip">Змінити шлях установки SPT-AKI.</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathTitle">Змінити</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathPlaceholder">Шлях установки SPT-AKI...</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -507,4 +507,8 @@
 	<system:String x:Key="DirectConnectViewModelAccountNotFoundDescription">Your account has not been found, would you like to register a new account with these credentials?</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonYes">Yes</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonNo">No</system:String>
+
+	<!-- MainViewModel -->
+	<system:String x:Key="MainViewModelUpdateErrorTitle">Error</system:String>
+	<system:String x:Key="MainViewModelUpdateErrorMessage">Failed when checking for updates</system:String>
 </ResourceDictionary>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -344,6 +344,7 @@
 	<system:String x:Key="ConfigureViewPersonalizationOptions">个性化和导入选项</system:String>
 
 	<!-- Install - Configure Server View -->
+	<system:String x:Key="ConfigureServerViewVersionSelectionErrorMessage">Unable to determine available SIT Server versions...</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathToolTip">更改 SPT-AKI 的安装路径。</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathTitle">更改</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathPlaceholder">SPT-AKI 安装路径...</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -507,4 +507,8 @@
 	<system:String x:Key="DirectConnectViewModelAccountNotFoundDescription">Your account has not been found, would you like to register a new account with these credentials?</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonYes">Yes</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonNo">No</system:String>
+
+	<!-- MainViewModel -->
+	<system:String x:Key="MainViewModelUpdateErrorTitle">Error</system:String>
+	<system:String x:Key="MainViewModelUpdateErrorMessage">Failed when checking for updates</system:String>
 </ResourceDictionary>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -506,4 +506,8 @@
 	<system:String x:Key="DirectConnectViewModelAccountNotFoundDescription">Your account has not been found, would you like to register a new account with these credentials?</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonYes">Yes</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonNo">No</system:String>
+
+	<!-- MainViewModel -->
+	<system:String x:Key="MainViewModelUpdateErrorTitle">Error</system:String>
+	<system:String x:Key="MainViewModelUpdateErrorMessage">Failed when checking for updates</system:String>
 </ResourceDictionary>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -343,6 +343,7 @@
 	<system:String x:Key="ConfigureViewVersionSelectionGroupTitle">版本選擇</system:String>
 
 	<!-- Install - Configure Server View -->
+	<system:String x:Key="ConfigureServerViewVersionSelectionErrorMessage">Unable to determine available SIT Server versions...</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathToolTip">更改 SPT-AKI 的安裝路徑。</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathTitle">更改</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathPlaceholder">SPT-AKI 安裝路徑...</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -507,4 +507,8 @@
 	<system:String x:Key="DirectConnectViewModelAccountNotFoundDescription">Your account has not been found, would you like to register a new account with these credentials?</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonYes">Yes</system:String>
 	<system:String x:Key="DirectConnectViewModelButtonNo">No</system:String>
+
+	<!-- MainViewModel -->
+	<system:String x:Key="MainViewModelUpdateErrorTitle">Error</system:String>
+	<system:String x:Key="MainViewModelUpdateErrorMessage">Failed when checking for updates</system:String>
 </ResourceDictionary>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -344,6 +344,7 @@
 	<system:String x:Key="ConfigureViewPersonalizationOptions">個人化和匯入選項</system:String>
 
 	<!-- Install - Configure Server View -->
+	<system:String x:Key="ConfigureServerViewVersionSelectionErrorMessage">Unable to determine available SIT Server versions...</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathToolTip">更改 SPT-AKI 的安裝路徑。</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathTitle">更改</system:String>
 	<system:String x:Key="ConfigureServerViewSPTAKIInstallPathPlaceholder">SPT-AKI 安裝路徑...</system:String>

--- a/SIT.Manager/ViewModels/MainViewModel.cs
+++ b/SIT.Manager/ViewModels/MainViewModel.cs
@@ -69,7 +69,7 @@ public partial class MainViewModel : ObservableRecipient, IRecipient<Installatio
 
         _localizationService.Translate(new CultureInfo(_managerConfigService.Config.CurrentLanguageSelected));
 
-        var faTheme = Application.Current?.Styles.OfType<FluentAvaloniaTheme>().FirstOrDefault();
+        FluentAvaloniaTheme? faTheme = Application.Current?.Styles.OfType<FluentAvaloniaTheme>().FirstOrDefault();
         if (faTheme != null) faTheme.CustomAccentColor = _managerConfigService.Config.AccentColor;
 
         _actionNotificationService.ActionNotificationReceived += ActionNotificationService_ActionNotificationReceived;
@@ -92,9 +92,10 @@ public partial class MainViewModel : ObservableRecipient, IRecipient<Installatio
             UpdateAvailable = await _appUpdaterService.CheckForUpdate();
             SitUpdateAvailable = await _installerService.IsSitUpdateAvailable();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-
+            _logger.LogError(ex, "Error checking for update to either Manager or SIT");
+            _barNotificationService.ShowError(_localizationService.TranslateSource("MainViewModelUpdateErrorTitle"), _localizationService.TranslateSource("MainViewModelUpdateErrorMessage"));
         }
     }
 

--- a/SIT.Manager/ViewModels/MainViewModel.cs
+++ b/SIT.Manager/ViewModels/MainViewModel.cs
@@ -87,8 +87,15 @@ public partial class MainViewModel : ObservableRecipient, IRecipient<Installatio
 
     private async Task CheckForUpdate()
     {
-        UpdateAvailable = await _appUpdaterService.CheckForUpdate();
-        SitUpdateAvailable = await _installerService.IsSitUpdateAvailable();
+        try
+        {
+            UpdateAvailable = await _appUpdaterService.CheckForUpdate();
+            SitUpdateAvailable = await _installerService.IsSitUpdateAvailable();
+        }
+        catch (Exception)
+        {
+
+        }
     }
 
     [RelayCommand]

--- a/SIT.Manager/Views/Installation/ConfigureServerView.axaml
+++ b/SIT.Manager/Views/Installation/ConfigureServerView.axaml
@@ -20,8 +20,26 @@
 				<TextBlock Text="{DynamicResource ConfigureViewVersionSelectionGroupTitle}" Classes="FrameHeading"/>
 				<Border Classes="StandardFrame">
 					<StackPanel>
-						<StackPanel Orientation="Horizontal"
-									IsVisible="{Binding !IsLoading}">
+						<TextBlock Text="{DynamicResource ConfigureServerViewVersionSelectionErrorMessage}"
+								   Classes="ErrorMessage"
+								   VerticalAlignment="Center"
+								   Margin="0,0,8,0">
+							<TextBlock.IsVisible>
+								<MultiBinding Converter="{x:Static BoolConverters.And}">
+									<Binding Path="!IsLoading"/>
+									<Binding Path="!HasVersionsAvailable"/>
+								</MultiBinding>
+							</TextBlock.IsVisible>
+						</TextBlock>
+						
+						<StackPanel Orientation="Horizontal">
+							<StackPanel.IsVisible>
+								<MultiBinding Converter="{x:Static BoolConverters.And}">
+									<Binding Path="!IsLoading"/>
+									<Binding Path="HasVersionsAvailable"/>
+								</MultiBinding>
+							</StackPanel.IsVisible>
+							
 							<TextBlock Text="{DynamicResource ConfigureServerViewVersionSelectionTitle}"
 									   VerticalAlignment="Center"
 									   Margin="0,0,8,0"/>

--- a/SIT.Manager/Views/Installation/ConfigureSitView.axaml
+++ b/SIT.Manager/Views/Installation/ConfigureSitView.axaml
@@ -136,7 +136,7 @@
 				</Border>
 			</StackPanel>
 
-			<StackPanel>
+			<StackPanel IsVisible="{Binding HasRecommendedModsAvailable}">
 				<TextBlock Text="{DynamicResource ConfigureSitViewRecommendedModsTitle}" Classes="FrameHeading"/>
 				<Border Classes="StandardFrame">
 					<StackPanel>


### PR DESCRIPTION
Add an error on the server install page if there is no version available to install. Also prevent a crash from occuring if the user navigates to the SIT install page with no internet.