### PR TITLE
Make EFT Path in settings clearer

### DIFF
--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -104,7 +104,14 @@
 	<system:String x:Key="SettingsServerConsoleTitle">Server Console</system:String>
 	<system:String x:Key="SettingsServerConsoleFontFamilyTitle">Font Family:</system:String>
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">Font Color:</system:String>
-	<system:String x:Key="SettingsManagerVersionTitle">Manager Version:</system:String>	
+	<system:String x:Key="SettingsManagerVersionTitle">Manager Version:</system:String>
+
+	<!-- EftView -->
+	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT Install Path:</system:String>
+	
+	<!-- EftViewModel -->
+	<system:String x:Key="EftViewModelBsgEftInstallPathMissing">Unable to detect BSG EFT install...</system:String>
+	<system:String x:Key="EftViewModelSitEftInstallPathMissing">SIT install not found. Please point to existing install here, or install by clicking the install button on the left</system:String>
 	
 	<!-- Linux Settings Page -->
 	<system:String x:Key="Key">Key</system:String>

--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -91,9 +91,8 @@
 	<system:String x:Key="SettingsAccentColorToolTip">Changes color of selected visuals to your choice!</system:String>
 	<system:String x:Key="SettingsEFTSettingsTitle">EFT</system:String>
 	<system:String x:Key="SettingsEFTSettingsButtonChangeTitle">Change</system:String>
-	<system:String x:Key="SettingsEFTInstallPathTitle">EFT Path:</system:String>
-	<system:String x:Key="SettingsEFTInstallPathPlaceholder">EFT Install Path...</system:String>
-	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Change the EFT Install Path.</system:String>
+	<system:String x:Key="SettingsEFTInstallPathTitle">SIT EFT Path:</system:String>
+	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Change the SIT EFT Install Path.</system:String>
 	<system:String x:Key="SettingsEFTVersionTitle">EFT Version:</system:String>
 	<system:String x:Key="SettingsSITVersionTitle">SIT Version:</system:String>
 	<system:String x:Key="SettingsSPTAKITitle">SPT-AKI</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -111,6 +111,13 @@
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">Цвет Шрифта:</system:String>
 	<system:String x:Key="SettingsManagerVersionTitle">Версия Менеджера (Лаунчера):</system:String>
 
+	<!-- EftView -->
+	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT Install Path:</system:String>
+
+	<!-- EftViewModel -->
+	<system:String x:Key="EftViewModelBsgEftInstallPathMissing">Unable to detect BSG EFT install...</system:String>
+	<system:String x:Key="EftViewModelSitEftInstallPathMissing">SIT install not found. Please point to existing install here, or install by clicking the install button on the left</system:String>
+
 	<!-- Linux Settings Page -->
 	<system:String x:Key="Key">Key</system:String>
 	<system:String x:Key="Value">Value</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -98,9 +98,8 @@
 	<system:String x:Key="SettingsLinuxWineRunnerToolTip">Установите используемую запускалку Wine для EFT</system:String>
 	<system:String x:Key="SettingsEFTSettingsTitle">Настройки EFT</system:String>
 	<system:String x:Key="SettingsEFTSettingsButtonChangeTitle">Сменить</system:String>
-	<system:String x:Key="SettingsEFTInstallPathTitle">Путь EFT:</system:String>
-	<system:String x:Key="SettingsEFTInstallPathPlaceholder">Путь Установки EFT...</system:String>
-	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Изменить Путь Установки EFT.</system:String>
+	<system:String x:Key="SettingsEFTInstallPathTitle">SIT EFT Path:</system:String>
+	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Change the SIT EFT Install Path.</system:String>
 	<system:String x:Key="SettingsEFTVersionTitle">Версия EFT:</system:String>
 	<system:String x:Key="SettingsSITVersionTitle">Версия SIT:</system:String>
 	<system:String x:Key="SettingsSPTAKITitle">Настройки SPT-AKI</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -115,6 +115,13 @@
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">Колір Шрифту:</system:String>
 	<system:String x:Key="SettingsManagerVersionTitle">Версія Менеджера (Лаунчера):</system:String>
 
+	<!-- EftView -->
+	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT Install Path:</system:String>
+
+	<!-- EftViewModel -->
+	<system:String x:Key="EftViewModelBsgEftInstallPathMissing">Unable to detect BSG EFT install...</system:String>
+	<system:String x:Key="EftViewModelSitEftInstallPathMissing">SIT install not found. Please point to existing install here, or install by clicking the install button on the left</system:String>
+
 	<!-- Linux Settings Page -->
 	<system:String x:Key="Key">Key</system:String>
 	<system:String x:Key="Value">Value</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -102,9 +102,8 @@
 	<system:String x:Key="SettingsLinuxWineRunnerToolTip">Встановіть використовуваний запускач Wine для EFT</system:String>
 	<system:String x:Key="SettingsEFTSettingsTitle">Налаштування EFT</system:String>
 	<system:String x:Key="SettingsEFTSettingsButtonChangeTitle">Змінити</system:String>
-	<system:String x:Key="SettingsEFTInstallPathTitle">Шлях EFT:</system:String>
-	<system:String x:Key="SettingsEFTInstallPathPlaceholder">Шлях Встановлення EFT...</system:String>
-	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Змінити Шлях Встановлення EFT.</system:String>
+	<system:String x:Key="SettingsEFTInstallPathTitle">SIT EFT Path:</system:String>
+	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Change the SIT EFT Install Path.</system:String>
 	<system:String x:Key="SettingsEFTVersionTitle">Версія EFT:</system:String>
 	<system:String x:Key="SettingsSITVersionTitle">Версія SIT:</system:String>
 	<system:String x:Key="SettingsSPTAKITitle">Налаштування SPT-AKI</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -111,6 +111,13 @@
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">字体颜色:</system:String>
 	<system:String x:Key="SettingsManagerVersionTitle">当前 SIT Manager 版本:</system:String>
 
+	<!-- EftView -->
+	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT Install Path:</system:String>
+
+	<!-- EftViewModel -->
+	<system:String x:Key="EftViewModelBsgEftInstallPathMissing">Unable to detect BSG EFT install...</system:String>
+	<system:String x:Key="EftViewModelSitEftInstallPathMissing">SIT install not found. Please point to existing install here, or install by clicking the install button on the left</system:String>
+
 	<!-- Linux Settings Page -->
 	<system:String x:Key="Key">Key</system:String>
 	<system:String x:Key="Value">Value</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -98,9 +98,8 @@
 	<system:String x:Key="SettingsLinuxWineRunnerToolTip">设置用于启动 EFT 的 wine runner</system:String>
 	<system:String x:Key="SettingsEFTSettingsTitle">EFT 设置</system:String>
 	<system:String x:Key="SettingsEFTSettingsButtonChangeTitle">更改</system:String>
-	<system:String x:Key="SettingsEFTInstallPathTitle">EFT 路径:</system:String>
-	<system:String x:Key="SettingsEFTInstallPathPlaceholder">EFT 安装路径...</system:String>
-	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">更改 EFT 安装路径</system:String>
+	<system:String x:Key="SettingsEFTInstallPathTitle">SIT EFT Path:</system:String>
+	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Change the SIT EFT Install Path.</system:String>
 	<system:String x:Key="SettingsEFTVersionTitle">EFT 版本:</system:String>
 	<system:String x:Key="SettingsSITVersionTitle">SIT 版本:</system:String>
 	<system:String x:Key="SettingsSPTAKITitle">SPT-AKI 设置</system:String>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -98,9 +98,8 @@
 	<system:String x:Key="SettingsLinuxWineRunnerToolTip">設置用於啟動 EFT 的 wine runner</system:String>
 	<system:String x:Key="SettingsEFTSettingsTitle">EFT 設定</system:String>
 	<system:String x:Key="SettingsEFTSettingsButtonChangeTitle">更改</system:String>
-	<system:String x:Key="SettingsEFTInstallPathTitle">EFT 路徑:</system:String>
-	<system:String x:Key="SettingsEFTInstallPathPlaceholder">EFT 安裝路徑...</system:String>
-	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">更改 EFT 安裝路徑</system:String>
+	<system:String x:Key="SettingsEFTInstallPathTitle">SIT EFT Path:</system:String>
+	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Change the SIT EFT Install Path.</system:String>
 	<system:String x:Key="SettingsEFTVersionTitle">EFT 版本:</system:String>
 	<system:String x:Key="SettingsSITVersionTitle">SIT 版本:</system:String>
 	<system:String x:Key="SettingsSPTAKITitle">SPT-AKI 設定</system:String>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -111,6 +111,13 @@
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">字型顏色:</system:String>
 	<system:String x:Key="SettingsManagerVersionTitle">當前 SIT Manager 版本:</system:String>
 
+	<!-- EftView -->
+	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT Install Path:</system:String>
+
+	<!-- EftViewModel -->
+	<system:String x:Key="EftViewModelBsgEftInstallPathMissing">Unable to detect BSG EFT install...</system:String>
+	<system:String x:Key="EftViewModelSitEftInstallPathMissing">SIT install not found. Please point to existing install here, or install by clicking the install button on the left</system:String>
+
 	<!-- Linux Settings Page -->
 	<system:String x:Key="Key">Key</system:String>
 	<system:String x:Key="Value">Value</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -111,6 +111,13 @@
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">字體顏色:</system:String>
 	<system:String x:Key="SettingsManagerVersionTitle">當前 SIT Manager 版本:</system:String>
 
+	<!-- EftView -->
+	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT Install Path:</system:String>
+
+	<!-- EftViewModel -->
+	<system:String x:Key="EftViewModelBsgEftInstallPathMissing">Unable to detect BSG EFT install...</system:String>
+	<system:String x:Key="EftViewModelSitEftInstallPathMissing">SIT install not found. Please point to existing install here, or install by clicking the install button on the left</system:String>
+
 	<!-- Linux Settings Page -->
 	<system:String x:Key="Key">Key</system:String>
 	<system:String x:Key="Value">Value</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -98,9 +98,8 @@
 	<system:String x:Key="SettingsLinuxWineRunnerToolTip">設置用於啟動 EFT 的 wine runner</system:String>
 	<system:String x:Key="SettingsEFTSettingsTitle">EFT 設定</system:String>
 	<system:String x:Key="SettingsEFTSettingsButtonChangeTitle">更改</system:String>
-	<system:String x:Key="SettingsEFTInstallPathTitle">EFT 路徑:</system:String>
-	<system:String x:Key="SettingsEFTInstallPathPlaceholder">EFT 安裝路徑...</system:String>
-	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">更改 EFT 安裝路徑</system:String>
+	<system:String x:Key="SettingsEFTInstallPathTitle">SIT EFT Path:</system:String>
+	<system:String x:Key="SettingsEFTChangeInstallPathToolTip">Change the SIT EFT Install Path.</system:String>
 	<system:String x:Key="SettingsEFTVersionTitle">EFT 版本:</system:String>
 	<system:String x:Key="SettingsSITVersionTitle">SIT 版本:</system:String>
 	<system:String x:Key="SettingsSPTAKITitle">SPT-AKI 設定</system:String>

--- a/SIT.Manager/Models/Config/ManagerConfig.cs
+++ b/SIT.Manager/Models/Config/ManagerConfig.cs
@@ -37,9 +37,9 @@ public partial class ManagerConfig : ObservableObject
 
     // SIT settings
     [ObservableProperty]
-    public string _installPath = string.Empty;
+    public string _sitEftInstallPath = string.Empty;
     [ObservableProperty]
-    public string _tarkovVersion = string.Empty;
+    public string _sitTarkovVersion = string.Empty;
     [ObservableProperty]
     public string _sitVersion = string.Empty;
     [ObservableProperty]

--- a/SIT.Manager/Services/FileService.cs
+++ b/SIT.Manager/Services/FileService.cs
@@ -156,7 +156,7 @@ public class FileService(IActionNotificationService actionNotificationService,
             Uri fileLink = new(fileUrl);
             INode fileNode = await megaApiClient.GetNodeFromLinkAsync(fileLink);
 
-            string targetPath = Path.Combine(_configService.Config.InstallPath, fileName);
+            string targetPath = Path.Combine(_configService.Config.SitEftInstallPath, fileName);
             await megaApiClient.DownloadFileAsync(fileNode, targetPath, progress);
 
             return true;

--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -66,32 +66,32 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
         _logger.LogInformation("Cleaning up EFT directory...");
         try
         {
-            string battlEyeDir = Path.Combine(_configService.Config.InstallPath, "BattlEye");
+            string battlEyeDir = Path.Combine(_configService.Config.SitEftInstallPath, "BattlEye");
             if (Directory.Exists(battlEyeDir))
             {
                 Directory.Delete(battlEyeDir, true);
             }
-            string battlEyeExe = Path.Combine(_configService.Config.InstallPath, "EscapeFromTarkov_BE.exe");
+            string battlEyeExe = Path.Combine(_configService.Config.SitEftInstallPath, "EscapeFromTarkov_BE.exe");
             if (File.Exists(battlEyeExe))
             {
                 File.Delete(battlEyeExe);
             }
-            string cacheDir = Path.Combine(_configService.Config.InstallPath, "cache");
+            string cacheDir = Path.Combine(_configService.Config.SitEftInstallPath, "cache");
             if (Directory.Exists(cacheDir))
             {
                 Directory.Delete(cacheDir, true);
             }
-            string consistencyPath = Path.Combine(_configService.Config.InstallPath, "ConsistencyInfo");
+            string consistencyPath = Path.Combine(_configService.Config.SitEftInstallPath, "ConsistencyInfo");
             if (File.Exists(consistencyPath))
             {
                 File.Delete(consistencyPath);
             }
-            string uninstallPath = Path.Combine(_configService.Config.InstallPath, "Uninstall.exe");
+            string uninstallPath = Path.Combine(_configService.Config.SitEftInstallPath, "Uninstall.exe");
             if (File.Exists(uninstallPath))
             {
                 File.Delete(uninstallPath);
             }
-            string logsDirPath = Path.Combine(_configService.Config.InstallPath, "Logs");
+            string logsDirPath = Path.Combine(_configService.Config.SitEftInstallPath, "Logs");
             if (Directory.Exists(logsDirPath))
             {
                 Directory.Delete(logsDirPath);
@@ -153,7 +153,7 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
             return sitVersions;
         }
 
-        string tarkovBuild = tarkovVersion ?? _configService.Config.TarkovVersion;
+        string tarkovBuild = tarkovVersion ?? _configService.Config.SitTarkovVersion;
         tarkovBuild = tarkovBuild.Split(".").Last();
 
         for (int i = 0; i < sitVersions.Count; i++)
@@ -530,20 +530,20 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
 
     public async Task<bool> IsSitUpdateAvailable()
     {
-        if (string.IsNullOrEmpty(_configService.Config.TarkovVersion) || string.IsNullOrEmpty(_configService.Config.SitVersion)) return false;
+        if (string.IsNullOrEmpty(_configService.Config.SitTarkovVersion) || string.IsNullOrEmpty(_configService.Config.SitVersion)) return false;
 
         TimeSpan timeSinceLastCheck = DateTime.Now - _configService.Config.LastSitUpdateCheckTime;
 
         if (timeSinceLastCheck.TotalHours >= 1)
         {
-            _availableSitUpdateVersions = await GetAvailableSitReleases(_configService.Config.TarkovVersion);
+            _availableSitUpdateVersions = await GetAvailableSitReleases(_configService.Config.SitTarkovVersion);
 
             if (_availableSitUpdateVersions != null)
             {
                 _availableSitUpdateVersions = _availableSitUpdateVersions
                     .Where(x => Version.TryParse(x.SitVersion.Replace("StayInTarkov.Client-", ""), out Version? sitVersion) &&
                                 sitVersion > Version.Parse(_configService.Config.SitVersion) &&
-                                _configService.Config.TarkovVersion == x.EftVersion)
+                                _configService.Config.SitTarkovVersion == x.EftVersion)
                     .ToList();
             }
 
@@ -745,8 +745,8 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
             extractionProgress.Report(100);
 
             ManagerConfig config = _configService.Config;
-            config.InstallPath = targetInstallDir;
-            config.TarkovVersion = _versionService.GetEFTVersion(targetInstallDir);
+            config.SitEftInstallPath = targetInstallDir;
+            config.SitTarkovVersion = _versionService.GetEFTVersion(targetInstallDir);
             config.SitVersion = _versionService.GetSITVersion(targetInstallDir);
             _configService.UpdateConfig(config);
         }

--- a/SIT.Manager/Services/ManagedProcesses/TarkovClientService.cs
+++ b/SIT.Manager/Services/ManagedProcesses/TarkovClientService.cs
@@ -31,13 +31,13 @@ public class TarkovClientService(IAkiServerRequestingService serverRequestingSer
     private readonly ILocalizationService _localizationService = localizationService;
     private readonly ILogger<TarkovClientService> _logger = logger;
 
-    public override string ExecutableDirectory => !string.IsNullOrEmpty(_configService.Config.InstallPath) ? _configService.Config.InstallPath : string.Empty;
+    public override string ExecutableDirectory => !string.IsNullOrEmpty(_configService.Config.SitEftInstallPath) ? _configService.Config.SitEftInstallPath : string.Empty;
 
     protected override string EXECUTABLE_NAME => TARKOV_EXE;
 
     private void ClearModCache()
     {
-        string cachePath = _configService.Config.InstallPath;
+        string cachePath = _configService.Config.SitEftInstallPath;
         if (!string.IsNullOrEmpty(cachePath) && Directory.Exists(cachePath))
         {
             // Combine the installPath with the additional subpath.

--- a/SIT.Manager/Services/ModService.cs
+++ b/SIT.Manager/Services/ModService.cs
@@ -128,7 +128,7 @@ public class ModService(IBarNotificationService barNotificationService,
                 ManagerConfig config = _configService.Config;
                 config.InstalledMods.Remove(mod.Name);
                 _configService.UpdateConfig(config);
-                await InstallMod(_configService.Config.InstallPath, mod, true).ConfigureAwait(false);
+                await InstallMod(_configService.Config.SitEftInstallPath, mod, true).ConfigureAwait(false);
             }
         }
         else

--- a/SIT.Manager/ViewModels/Installation/SelectViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/SelectViewModel.cs
@@ -33,7 +33,7 @@ public partial class SelectViewModel : InstallationViewModelBase
 
     private void EstablishEFTInstallStatus()
     {
-        if (string.IsNullOrEmpty(_configService.Config.InstallPath))
+        if (string.IsNullOrEmpty(_configService.Config.SitEftInstallPath))
         {
             string detectedBSGInstallPath = Path.GetDirectoryName(_installerService.GetEFTInstallPath()) ?? string.Empty;
             if (!string.IsNullOrEmpty(detectedBSGInstallPath))
@@ -45,7 +45,7 @@ public partial class SelectViewModel : InstallationViewModelBase
         }
         else
         {
-            CurrentInstallProcessState.EftInstallPath = _configService.Config.InstallPath;
+            CurrentInstallProcessState.EftInstallPath = _configService.Config.SitEftInstallPath;
             CurrentInstallProcessState.UsingBsgInstallPath = false;
         }
 

--- a/SIT.Manager/ViewModels/ModsPageViewModel.cs
+++ b/SIT.Manager/ViewModels/ModsPageViewModel.cs
@@ -67,7 +67,7 @@ public partial class ModsPageViewModel : ObservableRecipient
 
     private async Task LoadMasterList()
     {
-        if (string.IsNullOrEmpty(_managerConfigService.Config.InstallPath))
+        if (string.IsNullOrEmpty(_managerConfigService.Config.SitEftInstallPath))
         {
             _barNotificationService.ShowError(_localizationService.TranslateSource("ModsPageViewModelErrorTitle"), _localizationService.TranslateSource("ModsPageViewModelErrorInstallPathDescription"));
             return;
@@ -119,7 +119,7 @@ public partial class ModsPageViewModel : ObservableRecipient
 
     private async Task DownloadModPackage()
     {
-        if (string.IsNullOrEmpty(_managerConfigService.Config.InstallPath))
+        if (string.IsNullOrEmpty(_managerConfigService.Config.SitEftInstallPath))
         {
             _barNotificationService.ShowError(_localizationService.TranslateSource("ModsPageViewModelErrorTitle"), _localizationService.TranslateSource("ModsPageViewModelErrorInstallPathDescription"));
             return;
@@ -156,7 +156,7 @@ public partial class ModsPageViewModel : ObservableRecipient
             return;
         }
 
-        bool installSuccessful = await _modService.InstallMod(_managerConfigService.Config.InstallPath, SelectedMod);
+        bool installSuccessful = await _modService.InstallMod(_managerConfigService.Config.SitEftInstallPath, SelectedMod);
         EnableInstall = !installSuccessful;
     }
 
@@ -167,7 +167,7 @@ public partial class ModsPageViewModel : ObservableRecipient
             return;
         }
 
-        bool uninstallSuccessful = await _modService.UninstallMod(_managerConfigService.Config.InstallPath, SelectedMod);
+        bool uninstallSuccessful = await _modService.UninstallMod(_managerConfigService.Config.SitEftInstallPath, SelectedMod);
         EnableInstall = uninstallSuccessful;
     }
 

--- a/SIT.Manager/ViewModels/Play/DirectConnectViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/DirectConnectViewModel.cs
@@ -164,21 +164,21 @@ public partial class DirectConnectViewModel : ObservableRecipient
             {
                 Name = _localizationService.TranslateSource("DirectConnectViewModelInstallPathTitle"),
                 ErrorMessage = _localizationService.TranslateSource("DirectConnectViewModelInstallPathDescription"),
-                Check = () => { return !string.IsNullOrEmpty(_configService.Config.InstallPath); }
+                Check = () => { return !string.IsNullOrEmpty(_configService.Config.SitEftInstallPath); }
             },
             //SIT check
             new()
             {
                 Name = _localizationService.TranslateSource("DirectConnectViewModelSITInstallationTitle"),
                 ErrorMessage = _localizationService.TranslateSource("DirectConnectViewModelSITInstallationDescription", SIT_DLL_FILENAME),
-                Check = () => { return File.Exists(Path.Combine(_configService.Config.InstallPath, "BepInEx", "plugins", SIT_DLL_FILENAME)); }
+                Check = () => { return File.Exists(Path.Combine(_configService.Config.SitEftInstallPath, "BepInEx", "plugins", SIT_DLL_FILENAME)); }
             },
             //EFT Check
             new()
             {
                 Name = _localizationService.TranslateSource("DirectConnectViewModelEFTInstallationTitle"),
                 ErrorMessage = _localizationService.TranslateSource("DirectConnectViewModelEFTInstallationDescription", EFT_EXE_FILENAME),
-                Check = () => { return File.Exists(Path.Combine(_configService.Config.InstallPath, EFT_EXE_FILENAME)); }
+                Check = () => { return File.Exists(Path.Combine(_configService.Config.SitEftInstallPath, EFT_EXE_FILENAME)); }
             },
             //Field Check
             new()

--- a/SIT.Manager/ViewModels/Settings/EftViewModel.cs
+++ b/SIT.Manager/ViewModels/Settings/EftViewModel.cs
@@ -1,5 +1,8 @@
-﻿using CommunityToolkit.Mvvm.Input;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FluentAvalonia.UI.Controls;
 using SIT.Manager.Interfaces;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace SIT.Manager.ViewModels.Settings;
@@ -7,20 +10,36 @@ namespace SIT.Manager.ViewModels.Settings;
 public partial class EftViewModel : SettingsViewModelBase
 {
     private readonly IBarNotificationService _barNotificationService;
+    private readonly IInstallerService _installerService;
     private readonly ILocalizationService _localizationService;
     private readonly IVersionService _versionService;
+
+    [ObservableProperty]
+    private string _bsgEftInstallPath;
+
+    [ObservableProperty]
+    private string _sitEftInstallPath;
 
     public IAsyncRelayCommand ChangeInstallLocationCommand { get; }
 
     public EftViewModel(IBarNotificationService barNotificationService,
+        IInstallerService installerService,
         IManagerConfigService configService,
         ILocalizationService localizationService,
         IPickerDialogService pickerDialogService,
         IVersionService versionService) : base(configService, pickerDialogService)
     {
         _barNotificationService = barNotificationService;
+        _installerService = installerService;
         _localizationService = localizationService;
         _versionService = versionService;
+
+        BsgEftInstallPath = Path.GetDirectoryName(_installerService.GetEFTInstallPath()) ?? "Unable to detect BSG EFT install...";
+        SitEftInstallPath = _configsService.Config.SitEftInstallPath;
+        if (string.IsNullOrEmpty(SitEftInstallPath))
+        {
+            SitEftInstallPath = "SIT install not found. Please point to existing install here, or install by clicking the install button on the left";
+        }
 
         ChangeInstallLocationCommand = new AsyncRelayCommand(ChangeInstallLocation);
     }
@@ -30,9 +49,24 @@ public partial class EftViewModel : SettingsViewModelBase
         string targetPath = await GetPathLocation("EscapeFromTarkov.exe");
         if (!string.IsNullOrEmpty(targetPath))
         {
-            Config.InstallPath = targetPath;
-            Config.TarkovVersion = _versionService.GetEFTVersion(targetPath);
+            if (targetPath == BsgEftInstallPath)
+            {
+                // Using the same location as the current BSG install and we don't want this the same as the SIT install.
+                await new ContentDialog()
+                {
+                    Title = _localizationService.TranslateSource("ConfigureSitViewModelLocationSelectionErrorTitle"),
+                    Content = _localizationService.TranslateSource("ConfigureSitViewModelLocationSelectionErrorDescription"),
+                    PrimaryButtonText = _localizationService.TranslateSource("ConfigureSitViewModelLocationSelectionErrorOk")
+                }.ShowAsync();
+                return;
+            }
+
+            SitEftInstallPath = targetPath;
+
+            Config.SitTarkovVersion = targetPath;
+            Config.SitTarkovVersion = _versionService.GetEFTVersion(targetPath);
             Config.SitVersion = _versionService.GetSITVersion(targetPath);
+
             _barNotificationService.ShowInformational(_localizationService.TranslateSource("SettingsPageViewModelConfigTitle"), _localizationService.TranslateSource("SettingsPageViewModelConfigInformationEFTDescription", targetPath));
         }
         else

--- a/SIT.Manager/ViewModels/Settings/EftViewModel.cs
+++ b/SIT.Manager/ViewModels/Settings/EftViewModel.cs
@@ -34,11 +34,11 @@ public partial class EftViewModel : SettingsViewModelBase
         _localizationService = localizationService;
         _versionService = versionService;
 
-        BsgEftInstallPath = Path.GetDirectoryName(_installerService.GetEFTInstallPath()) ?? "Unable to detect BSG EFT install...";
+        BsgEftInstallPath = Path.GetDirectoryName(_installerService.GetEFTInstallPath()) ?? _localizationService.TranslateSource("EftViewModelBsgEftInstallPathMissing");
         SitEftInstallPath = _configsService.Config.SitEftInstallPath;
         if (string.IsNullOrEmpty(SitEftInstallPath))
         {
-            SitEftInstallPath = "SIT install not found. Please point to existing install here, or install by clicking the install button on the left";
+            SitEftInstallPath = _localizationService.TranslateSource("EftViewModelSitEftInstallPathMissing");
         }
 
         ChangeInstallLocationCommand = new AsyncRelayCommand(ChangeInstallLocation);

--- a/SIT.Manager/ViewModels/ToolsPageViewModel.cs
+++ b/SIT.Manager/ViewModels/ToolsPageViewModel.cs
@@ -75,7 +75,7 @@ public partial class ToolsPageViewModel : ObservableObject
 
     private async Task OpenEFTFolder()
     {
-        if (string.IsNullOrEmpty(_configService.Config.InstallPath))
+        if (string.IsNullOrEmpty(_configService.Config.SitEftInstallPath))
         {
             ContentDialog contentDialog = new()
             {
@@ -87,13 +87,13 @@ public partial class ToolsPageViewModel : ObservableObject
         }
         else
         {
-            await _fileService.OpenDirectoryAsync(_configService.Config.InstallPath);
+            await _fileService.OpenDirectoryAsync(_configService.Config.SitEftInstallPath);
         }
     }
 
     private async Task OpenBepInExFolder()
     {
-        if (string.IsNullOrEmpty(_configService.Config.InstallPath))
+        if (string.IsNullOrEmpty(_configService.Config.SitEftInstallPath))
         {
             ContentDialog contentDialog = new()
             {
@@ -105,7 +105,7 @@ public partial class ToolsPageViewModel : ObservableObject
         }
         else
         {
-            string dirPath = Path.Combine(_configService.Config.InstallPath, "BepInEx", "plugins");
+            string dirPath = Path.Combine(_configService.Config.SitEftInstallPath, "BepInEx", "plugins");
             if (Directory.Exists(dirPath))
             {
                 await _fileService.OpenDirectoryAsync(dirPath);
@@ -133,7 +133,7 @@ public partial class ToolsPageViewModel : ObservableObject
 
     private async Task OpenSITConfig()
     {
-        string path = Path.Combine(_configService.Config.InstallPath, "BepInEx", "config");
+        string path = Path.Combine(_configService.Config.SitEftInstallPath, "BepInEx", "config");
         if (!Directory.Exists(path))
         {
             ContentDialog contentDialog = new()

--- a/SIT.Manager/Views/Settings/EftView.axaml
+++ b/SIT.Manager/Views/Settings/EftView.axaml
@@ -13,7 +13,7 @@
 			<!--BSG EFT Install Path-->
 			<TextBlock Grid.Column="0"
 					   Grid.Row="0"
-					   Text="BSG EFT Install Path:"
+					   Text="{DynamicResource EftViewBsgEftInstallPath}"
 					   Margin="0,0,12,0"
 					   VerticalAlignment="Center"/>
 			<TextBlock Margin="0,0,12,0"

--- a/SIT.Manager/Views/Settings/EftView.axaml
+++ b/SIT.Manager/Views/Settings/EftView.axaml
@@ -7,28 +7,63 @@
              x:Class="SIT.Manager.Views.Settings.EftView"
 			 x:DataType="vm:EftViewModel">
 	<Border Classes="StandardFrame">
-		<StackPanel>
-			<StackPanel Orientation="Horizontal" >
-				<TextBlock Text="{DynamicResource SettingsEFTInstallPathTitle}" Margin="0,0,10,0" VerticalAlignment="Center"/>
-				<TextBox Watermark="{DynamicResource SettingsEFTInstallPathPlaceholder}"
-						 Margin="0,0,10,0"
-						 MaxWidth="400"
-						 IsReadOnly="True"
-						 Text="{Binding Config.InstallPath}"/>
-				<Button Name="ChangeInstallButton"
-						Content="{DynamicResource SettingsEFTSettingsButtonChangeTitle}"
-						Margin="0,0,10,0"
-						ToolTip.Tip="{DynamicResource SettingsEFTChangeInstallPathToolTip}"
-						Command="{Binding ChangeInstallLocationCommand}"/>
-			</StackPanel>
-			<StackPanel Orientation="Horizontal">
-				<TextBlock Text="{DynamicResource SettingsEFTVersionTitle}" Margin="0,10,10,0" VerticalAlignment="Center"/>
-				<SelectableTextBlock Text="{Binding Config.TarkovVersion, Mode=TwoWay}" Margin="0,10,10,0" VerticalAlignment="Center"/>
-			</StackPanel>
-			<StackPanel Orientation="Horizontal">
-				<TextBlock Text="{DynamicResource SettingsSITVersionTitle}" Margin="0,10,10,0" VerticalAlignment="Center"/>
-				<SelectableTextBlock Text="{Binding Config.SitVersion, Mode=TwoWay}" Margin="0,10,10,0" VerticalAlignment="Center"/>
-			</StackPanel>
-		</StackPanel>
+		<Grid Margin="0,8,0,0"
+			  RowDefinitions="Auto, Auto, Auto, Auto"
+			  ColumnDefinitions="Auto, *, Auto">
+			<!--BSG EFT Install Path-->
+			<TextBlock Grid.Column="0"
+					   Grid.Row="0"
+					   Text="BSG EFT Install Path:"
+					   Margin="0,0,12,0"
+					   VerticalAlignment="Center"/>
+			<TextBlock Margin="0,0,12,0"
+					   Grid.Column="1"
+					   Grid.Row="0"
+					   TextWrapping="WrapWithOverflow"
+					   VerticalAlignment="Center"
+					   Text="{Binding BsgEftInstallPath}"/>
+
+			<!--SIT EFT Install Path-->		
+			<TextBlock Grid.Column="0"
+					   Grid.Row="1"
+					   Text="{DynamicResource SettingsEFTInstallPathTitle}"
+					   Margin="0,12,12,0"
+					   VerticalAlignment="Center"/>
+			<TextBlock Grid.Column="1"
+					   Grid.Row="1"
+					   Margin="0,12,12,0"
+					   TextWrapping="WrapWithOverflow"
+					   Text="{Binding SitEftInstallPath}"/>
+			<Button Grid.Column="2"
+					Grid.Row="1"
+					Content="{DynamicResource SettingsEFTSettingsButtonChangeTitle}"
+					Margin="0,12,12,0"
+					ToolTip.Tip="{DynamicResource SettingsEFTChangeInstallPathToolTip}"
+					Command="{Binding ChangeInstallLocationCommand}"/>
+
+			<!--SIT EFT Version-->
+			<TextBlock Grid.Column="0"
+					   Grid.Row="2"
+					   Text="{DynamicResource SettingsEFTVersionTitle}"
+					   Margin="0,12,8,0"
+					   VerticalAlignment="Center"/>
+			<SelectableTextBlock Grid.Column="1"
+								 Grid.Row="2"
+								 Margin="0,12,8,0"
+								 Text="{Binding Config.SitTarkovVersion}"
+								 VerticalAlignment="Center"/>
+
+			<!--SIT Mod Version-->
+			<TextBlock Grid.Column="0"
+					   Grid.Row="3"
+					   Text="{DynamicResource SettingsSITVersionTitle}"
+					   Margin="0,12,8,0"
+					   VerticalAlignment="Center"/>
+			<SelectableTextBlock Grid.Column="0"
+								 Grid.Row="3"
+								 Margin="0,12,8,0"
+								 Text="{Binding Config.SitVersion}"
+								 VerticalAlignment="Center"/>
+		</Grid>
 	</Border>
 </UserControl>

--- a/SIT.Manager/Views/Settings/EftView.axaml
+++ b/SIT.Manager/Views/Settings/EftView.axaml
@@ -59,7 +59,7 @@
 					   Text="{DynamicResource SettingsSITVersionTitle}"
 					   Margin="0,12,8,0"
 					   VerticalAlignment="Center"/>
-			<SelectableTextBlock Grid.Column="0"
+			<SelectableTextBlock Grid.Column="1"
 								 Grid.Row="3"
 								 Margin="0,12,8,0"
 								 Text="{Binding Config.SitVersion}"


### PR DESCRIPTION
Should hopefully make the EFT path setting much clearer, and also harder to select the BSG EFT install by mistake now.

I think this is the nicest way of displaying it and doing it but am open to any suggestions.

![image](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/112902041/d50d185d-2e68-4f1c-8659-4e526b610895)
