### PR TITLE
Add Launch Params

### DIFF
--- a/SIT.Manager.Desktop/Program.cs
+++ b/SIT.Manager.Desktop/Program.cs
@@ -14,7 +14,7 @@ class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        AppBuilder aB = BuildAvaloniaApp();
+        AppBuilder aB = BuildAvaloniaApp(args);
         try
         {
             aB.StartWithClassicDesktopLifetime(args);
@@ -28,8 +28,8 @@ class Program
     }
 
     // Avalonia configuration, don't remove; also used by visual designer.
-    public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+    public static AppBuilder BuildAvaloniaApp(string[] args)
+        => AppBuilder.Configure(() => new App(args))
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();

--- a/SIT.Manager/App.axaml.cs
+++ b/SIT.Manager/App.axaml.cs
@@ -19,9 +19,11 @@ using SIT.Manager.ViewModels.Play;
 using SIT.Manager.ViewModels.Settings;
 using SIT.Manager.Views;
 using System;
+using System.CommandLine;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace SIT.Manager;
 
@@ -37,9 +39,15 @@ public sealed partial class App : Application
     /// </summary>
     public IServiceProvider Services { get; }
 
-    public App()
+
+    public App(string[] args)
     {
         Services = ConfigureServices;
+
+        if (args.Length > 0)
+        {
+            Task.Run(() => ParseArguments(args));
+        }
     }
 
     /// <summary>
@@ -212,5 +220,38 @@ public sealed partial class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    private Task ParseArguments(string[] args)
+    {
+        var addressOption = new Option<string>
+            ("--address", "AKI server to connect to. If omitted this will start a local server.");
+
+        var usernameOption = new Option<string>
+            ("--username", "Username of the account to connect with");
+
+        var passwordOption = new Option<string>
+            ("--password", "Password of the account to connect with");
+
+        addressOption.AddAlias("-a");
+        usernameOption.AddAlias("-u");
+        passwordOption.AddAlias("-p");
+
+        var rootCommand = new RootCommand
+        {
+            addressOption,
+            usernameOption,
+            passwordOption,
+        };
+
+        rootCommand.SetHandler((addressValue, usernameValue, passwordValue) =>
+        {
+            var dcvm = Services.GetService<DirectConnectViewModel>();
+
+            return dcvm.ConnectToServer(addressValue, usernameValue, passwordValue);
+
+        }, addressOption, usernameOption, passwordOption);
+
+        return rootCommand.InvokeAsync(args);
     }
 }

--- a/SIT.Manager/App.axaml.cs
+++ b/SIT.Manager/App.axaml.cs
@@ -222,7 +222,7 @@ public sealed partial class App : Application
         base.OnFrameworkInitializationCompleted();
     }
 
-    private Task ParseArguments(string[] args)
+    private Task<int> ParseArguments(string[] args)
     {
         var addressOption = new Option<string>
             ("--address", "AKI server to connect to. If omitted this will start a local server.");
@@ -244,11 +244,15 @@ public sealed partial class App : Application
             passwordOption,
         };
 
-        rootCommand.SetHandler((addressValue, usernameValue, passwordValue) =>
+        rootCommand.SetHandler(async (addressValue, usernameValue, passwordValue) =>
         {
-            var dcvm = Services.GetService<DirectConnectViewModel>();
 
-            return dcvm.ConnectToServer(addressValue, usernameValue, passwordValue);
+            if (usernameValue != null && passwordValue != null)
+            {
+                var dcvm = Services.GetService<DirectConnectViewModel>();
+
+                await dcvm.ConnectToServer(addressValue, usernameValue, passwordValue);
+            }
 
         }, addressOption, usernameOption, passwordOption);
 

--- a/SIT.Manager/SIT.Manager.csproj
+++ b/SIT.Manager/SIT.Manager.csproj
@@ -46,6 +46,7 @@
         <PackageReference Include="Polly.Extensions" Version="8.3.1" />
         <PackageReference Include="SharpCompress" Version="0.36.0" />
         <PackageReference Include="SkiaSharp" Version="2.88.8" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     </ItemGroup>
 

--- a/SIT.Manager/ViewModels/Play/DirectConnectViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/DirectConnectViewModel.cs
@@ -75,6 +75,28 @@ public partial class DirectConnectViewModel : ObservableRecipient
         QuickPlayCommand = new AsyncRelayCommand(async () => await ConnectToServer(true));
     }
 
+    public Task ConnectToServer(string address, string username, string password) 
+    {
+        if(!string.IsNullOrEmpty(address))
+        {
+            LastServer = address;
+        }
+
+        if(!string.IsNullOrEmpty(username))
+        {
+            Username = username;
+        }
+
+        if(!string.IsNullOrEmpty(password))
+        {
+            Password = password;
+        }
+
+        var startServer = address == null;
+
+        return ConnectToServer(startServer);
+    }
+
     private async Task ConnectToServer(bool launchServer = false)
     {
         if (string.IsNullOrEmpty(_configService.Config.SitVersion) && string.IsNullOrEmpty(_configService.Config.SitTarkovVersion))

--- a/SIT.Manager/ViewModels/Play/DirectConnectViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/DirectConnectViewModel.cs
@@ -81,6 +81,10 @@ public partial class DirectConnectViewModel : ObservableRecipient
         {
             LastServer = address;
         }
+        else
+        {
+            LastServer = "127.0.0.1";
+        }
 
         if(!string.IsNullOrEmpty(username))
         {


### PR DESCRIPTION
Closes #170 

This PR adds the launch params described in the issue.

--address (-a): sets the server address to connect to, if omitted this will start a local server
--username (-u): sets the username of the account to login with
--password (-p): sets the password of the account to login with