### PR TITLE
Hide start server button

### DIFF
--- a/SIT.Manager/ViewModels/Play/DirectConnectViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/DirectConnectViewModel.cs
@@ -47,6 +47,9 @@ public partial class DirectConnectViewModel : ObservableRecipient
     [ObservableProperty]
     private string _quickPlayText = string.Empty;
 
+    [ObservableProperty]
+    private bool _isLocalServerRunning = false;
+
     public IAsyncRelayCommand ConnectToServerCommand { get; }
     public IAsyncRelayCommand QuickPlayCommand { get; }
 
@@ -76,9 +79,9 @@ public partial class DirectConnectViewModel : ObservableRecipient
         QuickPlayCommand = new AsyncRelayCommand(async () => await ConnectToServer(true));
     }
 
-    public Task ConnectToServer(string address, string username, string password) 
+    public Task ConnectToServer(string address, string username, string password)
     {
-        if(!string.IsNullOrEmpty(address))
+        if (!string.IsNullOrEmpty(address))
         {
             LastServer = address;
         }
@@ -87,12 +90,12 @@ public partial class DirectConnectViewModel : ObservableRecipient
             LastServer = "127.0.0.1";
         }
 
-        if(!string.IsNullOrEmpty(username))
+        if (!string.IsNullOrEmpty(username))
         {
             Username = username;
         }
 
-        if(!string.IsNullOrEmpty(password))
+        if (!string.IsNullOrEmpty(password))
         {
             Password = password;
         }
@@ -308,6 +311,7 @@ public partial class DirectConnectViewModel : ObservableRecipient
         }
 
         QuickPlayText = _localizationService.TranslateSource("DirectConnectViewModelQuickPlayText");
+        IsLocalServerRunning = _akiServerService.State == RunningState.Running || _akiServerService.State == RunningState.Starting;
         return aborted;
     }
 
@@ -316,5 +320,6 @@ public partial class DirectConnectViewModel : ObservableRecipient
         base.OnActivated();
 
         QuickPlayText = _localizationService.TranslateSource("DirectConnectViewModelQuickPlayText");
+        IsLocalServerRunning = _akiServerService.State == RunningState.Running || _akiServerService.State == RunningState.Starting;
     }
 }

--- a/SIT.Manager/Views/Play/DirectConnectView.axaml
+++ b/SIT.Manager/Views/Play/DirectConnectView.axaml
@@ -28,7 +28,7 @@
 					<Label Content="{DynamicResource DirectConnectViewPasswordBoxTitle}" Margin="10 10 10 0" FontWeight="Bold" FontSize="14"/>
 					<TextBox Name="PasswordBox" Text="{Binding Password, Mode=TwoWay}" MinWidth="300" Margin="8 4 8 8" HorizontalAlignment="Left" PasswordChar="●" Watermark="{DynamicResource DirectConnectViewEnterPasswordPlaceholder}"/>
 					<CheckBox Name="RememberMeCheck" Content="{DynamicResource DirectConnectViewRememberMeCheckBoxTitle}" Margin="8" IsChecked="{Binding RememberMe}"/>
-					<Grid ColumnDefinitions="*, *" Margin="8">
+					<Grid ColumnDefinitions="*, auto" Margin="8">
 						<Button Name="ConnectButton"
 								Grid.Column="0"
 								HorizontalAlignment="Stretch"

--- a/SIT.Manager/Views/Play/DirectConnectView.axaml
+++ b/SIT.Manager/Views/Play/DirectConnectView.axaml
@@ -37,12 +37,18 @@
 								ToolTip.Tip="{DynamicResource DirectConnectViewConnectButtonTitleToolTip}"
 								Margin="0,0,4,0"></Button>
 						<Button Name="QuickPlayButton"
-								IsVisible="{Binding ManagerConfig.AkiServerPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
 								HorizontalAlignment="Stretch"
 								Grid.Column="1"
 								Command="{Binding QuickPlayCommand}"
 								ToolTip.Tip="{DynamicResource DirectConnectViewStartServerAndConnectButtonTitleToolTip}"
 								Margin="4,0,0,0">
+							<Button.IsVisible>
+								<MultiBinding Converter="{x:Static BoolConverters.And}">
+									<Binding Path="ManagerConfig.AkiServerPath" Converter="{x:Static StringConverters.IsNotNullOrEmpty}"/>
+									<Binding Path="!IsLocalServerRunning"/>
+								</MultiBinding>
+							</Button.IsVisible>
+							
 							<StackPanel Orientation="Horizontal">
 								<TextBlock Text="{Binding QuickPlayText}"/>
 								<controls:LoadingSpinner Width="12"

--- a/SIT.Manager/Views/Play/DirectConnectView.axaml
+++ b/SIT.Manager/Views/Play/DirectConnectView.axaml
@@ -37,6 +37,7 @@
 								ToolTip.Tip="{DynamicResource DirectConnectViewConnectButtonTitleToolTip}"
 								Margin="0,0,4,0"></Button>
 						<Button Name="QuickPlayButton"
+								IsVisible="{Binding ManagerConfig.AkiServerPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
 								HorizontalAlignment="Stretch"
 								Grid.Column="1"
 								Command="{Binding QuickPlayCommand}"


### PR DESCRIPTION
Does 2 things:

- Hide the `Start Server and Connect button`, if no server path set to resolve #239 
- Hide the `Start Server and Connect button` if the local server is started/running to at least partly resolve #216