### PR TITLE
Convert Developer mode to Test Mode

### DIFF
--- a/SIT.Manager.Desktop/Program.cs
+++ b/SIT.Manager.Desktop/Program.cs
@@ -33,4 +33,6 @@ class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+    public static AppBuilder BuildAvaloniaApp() => BuildAvaloniaApp([]);
 }

--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -87,8 +87,8 @@
 	<system:String x:Key="SettingsLookForUpdatesTitleToolTip">Automatically look for updates when opening the launcher.</system:String>
 	<system:String x:Key="SettingsHideIpAddressTitle">Hide Ip Address</system:String>
 	<system:String x:Key="SettingsHideIpAddressToolTip">Hides the Ip Address with the star symbols in Ip Address Box.</system:String>
-	<system:String x:Key="SettingsEnableDeveloperMode">Enable Developer Mode</system:String>
-	<system:String x:Key="SettingsEnableDeveloperModeToolTip">Enables developer/test releases of SIT and SIT server for testing purposes</system:String>
+	<system:String x:Key="SettingsEnableTestMode">Show SIT Test Versions Only</system:String>
+	<system:String x:Key="SettingsEnableTestModeToolTip">Will show only test releases of SIT and AKI server for installation</system:String>
 	<system:String x:Key="SettingsLanguageTitle">Language:</system:String>
 	<system:String x:Key="SettingsLanguageTitleToolTip">Translates entire launcher to your language, select one!</system:String>
 	<system:String x:Key="SettingsAccentColorTitle">Accent Color:</system:String>

--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -261,8 +261,8 @@
 	<system:String x:Key="SettingsPageViewModelConfigInformationEFTDescription">EFT installation path set to '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigInformationSPTAKIDescription">SPT-AKI installation path set to '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigErrorSPTAKI">The selected folder was invalid. Make sure it's a proper SPT-AKI server folder.</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Enable Developer Mod Failure</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Can't enable developer mode as you have %1 incompatible mods still enabled</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Enable Test Mode Failure</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Can't enable test mode as you have %1 incompatible mods still enabled</system:String>
 	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorButtonOk">Ok</system:String>
 
 	<!-- Server Page ViewModel -->

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -87,8 +87,8 @@
 	<system:String x:Key="SettingsLookForUpdatesTitleToolTip">Автоматически проверяет обновления при открытии лаунчера.</system:String>
 	<system:String x:Key="SettingsHideIpAddressTitle">Скрыть IP-адрес</system:String>
 	<system:String x:Key="SettingsHideIpAddressToolTip">Скрывает IP-адрес звездочками в поле IP-адреcа.</system:String>
-	<system:String x:Key="SettingsEnableDeveloperMode">Включить режим разработчика</system:String>
-	<system:String x:Key="SettingsEnableDeveloperModeToolTip">Позволяет разработчикам/тестерам выпускать SIT и SIT-сервер для целей тестирования</system:String>
+	<system:String x:Key="SettingsEnableTestMode">Show SIT Test Versions Only</system:String>
+	<system:String x:Key="SettingsEnableTestModeToolTip">Will show only test releases of SIT and AKI server for installation</system:String>
 	<system:String x:Key="SettingsLanguageTitle">Язык:</system:String>
 	<system:String x:Key="SettingsLanguageTitleToolTip">Переводит весь лаунчер на ваш язык, выберите свой язык!</system:String>
 	<system:String x:Key="SettingsAccentColorTitle">Цвет акцента:</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -265,8 +265,8 @@
 	<system:String x:Key="SettingsPageViewModelConfigInformationEFTDescription">Путь установки EFT установлен на '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigInformationSPTAKIDescription">Путь установки SPT-AKI установлен на '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigErrorSPTAKI">Выбранная папка недействительна. Убедитесь, что это правильная папка сервера SPT-AKI.</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Ошибка включения режима разработчика</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Невозможно включить режим разработчика, так-как у вас %1 несовместимые моды все еще включены</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Enable Test Mode Failure</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Can't enable test mode as you have %1 incompatible mods still enabled</system:String>
 	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorButtonOk">Ок</system:String>
 
 	<!-- Server Page ViewModel -->

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -270,8 +270,8 @@
 	<system:String x:Key="SettingsPageViewModelConfigInformationEFTDescription">Шлях встановлення EFT встановлено на '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigInformationSPTAKIDescription">Шлях встановлення SPT-AKI встановлено на '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigErrorSPTAKI">Вибрана тека є недійсною. Переконайтеся, що це вірна тека сервера SPT-AKI.</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Помилка ввімкнення режиму розробника</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Неможливо ввімкнути режим розробника, бо у вас %1 несумісні моди все ще ввімкнені</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Enable Test Mode Failure</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Can't enable test mode as you have %1 incompatible mods still enabled</system:String>
 	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorButtonOk">Ок</system:String>
 
 	<!-- Server Page ViewModel -->

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -91,8 +91,8 @@
 	<system:String x:Key="SettingsLookForUpdatesTitleToolTip">Автоматично перевіряє оновлення при відкритті лаунчера.</system:String>
 	<system:String x:Key="SettingsHideIpAddressTitle">Сховати IP-адресу</system:String>
 	<system:String x:Key="SettingsHideIpAddressToolTip">Приховує IP-адресу зірочками в полі IP-адреси.</system:String>
-	<system:String x:Key="SettingsEnableDeveloperMode">Увімкнути режим розробника</system:String>
-	<system:String x:Key="SettingsEnableDeveloperModeToolTip">Увімкнення режиму розробника/тестових випусків SIT та сервера SIT для тестування</system:String>
+	<system:String x:Key="SettingsEnableTestMode">Show SIT Test Versions Only</system:String>
+	<system:String x:Key="SettingsEnableTestModeToolTip">Will show only test releases of SIT and AKI server for installation</system:String>
 	<system:String x:Key="SettingsLanguageTitle">Мова:</system:String>
 	<system:String x:Key="SettingsLanguageTitleToolTip">Перекладає весь лаунчер на вашу мову, оберіть свою мову!</system:String>
 	<system:String x:Key="SettingsAccentColorTitle">Колір акценту:</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -266,8 +266,8 @@
 	<system:String x:Key="SettingsPageViewModelConfigInformationEFTDescription">EFT 安装路径已设置为 '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigInformationSPTAKIDescription">SPT-AKI 服务器安装路径已设置为 '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigErrorSPTAKI">所选文件夹无效，请确保它是正确的 SPT-AKI 服务器文件夹！</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">启用开发者模式错误</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">无法启用开发者模式，因为您仍然有 %1 不兼容的模式处于启用状态</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Enable Test Mode Failure</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Can't enable test mode as you have %1 incompatible mods still enabled</system:String>
 	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorButtonOk">确定</system:String>
 
 	<!-- Server Page ViewModel -->

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -87,8 +87,8 @@
 	<system:String x:Key="SettingsLookForUpdatesTitleToolTip">打开启动器时自动检查更新</system:String>
 	<system:String x:Key="SettingsHideIpAddressTitle">隐藏 IP 地址</system:String>
 	<system:String x:Key="SettingsHideIpAddressToolTip">在 IP 地址框中用星号隐藏 IP 地址。</system:String>
-	<system:String x:Key="SettingsEnableDeveloperMode">启用开发者模式</system:String>
-	<system:String x:Key="SettingsEnableDeveloperModeToolTip">启用开发者/测试版 SIT 和 SIT 服务器以进行测试目的</system:String>
+	<system:String x:Key="SettingsEnableTestMode">Show SIT Test Versions Only</system:String>
+	<system:String x:Key="SettingsEnableTestModeToolTip">Will show only test releases of SIT and AKI server for installation</system:String>
 	<system:String x:Key="SettingsLanguageTitle">语言:</system:String>
 	<system:String x:Key="SettingsLanguageTitleToolTip">将整个启动器翻译为您的语言，选择其中一种!</system:String>
 	<system:String x:Key="SettingsAccentColorTitle">强调颜色:</system:String>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -266,8 +266,8 @@
 	<system:String x:Key="SettingsPageViewModelConfigInformationEFTDescription">EFT 安裝路徑已設置為 '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigInformationSPTAKIDescription">SPT-AKI 伺服器安裝路徑已設置為 '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigErrorSPTAKI">所選文件夾無效，請確保它是正確的 SPT-AKI 伺服器文件夾！</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">啟用開發者模式錯誤</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">無法啟用開發者模式，因為您仍然有 %1 不相容的模式處於啟用狀態</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Enable Test Mode Failure</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Can't enable test mode as you have %1 incompatible mods still enabled</system:String>	
 	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorButtonOk">確定</system:String>
 
 	<!-- Server Page ViewModel -->

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -87,8 +87,8 @@
 	<system:String x:Key="SettingsLookForUpdatesTitleToolTip">啟動啟動器時自動檢查更新</system:String>
 	<system:String x:Key="SettingsHideIpAddressTitle">隱藏 IP 地址</system:String>
 	<system:String x:Key="SettingsHideIpAddressToolTip">在 IP 地址框中用星號隱藏 IP 地址。</system:String>
-	<system:String x:Key="SettingsEnableDeveloperMode">啟用開發者模式</system:String>
-	<system:String x:Key="SettingsEnableDeveloperModeToolTip">啟用開發者/測試版本的 SIT 和 SIT 伺服器，以進行測試用途</system:String>
+	<system:String x:Key="SettingsEnableTestMode">Show SIT Test Versions Only</system:String>
+	<system:String x:Key="SettingsEnableTestModeToolTip">Will show only test releases of SIT and AKI server for installation</system:String>
 	<system:String x:Key="SettingsLanguageTitle">語言:</system:String>
 	<system:String x:Key="SettingsLanguageTitleToolTip">將整個啟動器翻譯為您的語言，選擇其中一種！</system:String>
 	<system:String x:Key="SettingsAccentColorTitle">強調顏色:</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -87,8 +87,8 @@
 	<system:String x:Key="SettingsLookForUpdatesTitleToolTip">開啟啟動器時自動檢查更新</system:String>
 	<system:String x:Key="SettingsHideIpAddressTitle">隱藏 IP 位址</system:String>
 	<system:String x:Key="SettingsHideIpAddressToolTip">在 IP 位址框中使用星號隱藏 IP 位址。</system:String>
-	<system:String x:Key="SettingsEnableDeveloperMode">啟用開發者模式</system:String>
-	<system:String x:Key="SettingsEnableDeveloperModeToolTip">啟用開發者/測試版本的 SIT 和 SIT 伺服器，以進行測試用途</system:String>
+	<system:String x:Key="SettingsEnableTestMode">Show SIT Test Versions Only</system:String>
+	<system:String x:Key="SettingsEnableTestModeToolTip">Will show only test releases of SIT and AKI server for installation</system:String>
 	<system:String x:Key="SettingsLanguageTitle">語言:</system:String>
 	<system:String x:Key="SettingsLanguageTitleToolTip">將整個啟動器翻譯為您的語言，選擇其中一種!</system:String>
 	<system:String x:Key="SettingsAccentColorTitle">強調顏色:</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -266,8 +266,8 @@
 	<system:String x:Key="SettingsPageViewModelConfigInformationEFTDescription">EFT 安裝路徑已設置為 '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigInformationSPTAKIDescription">SPT-AKI 伺服器安裝路徑已設置為 '%1'</system:String>
 	<system:String x:Key="SettingsPageViewModelConfigErrorSPTAKI">所選檔案夾無效，請確保它是正確的 SPT-AKI 伺服器檔案夾！</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">啟用開發者模式錯誤</system:String>
-	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">無法啟用開發者模式，因為您仍然有 %1 不相容的模式處於啟用狀態</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorTitle">Enable Test Mode Failure</system:String>
+	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorDescription">Can't enable test mode as you have %1 incompatible mods still enabled</system:String>
 	<system:String x:Key="SettingsPageViewModelEnableDevModeErrorButtonOk">確定</system:String>
 
 	<!-- Server Page ViewModel -->

--- a/SIT.Manager/Models/Config/ManagerConfig.cs
+++ b/SIT.Manager/Models/Config/ManagerConfig.cs
@@ -17,7 +17,7 @@ public partial class ManagerConfig : ObservableObject
     [ObservableProperty]
     public string _currentLanguageSelected = CultureInfo.CurrentCulture.Name;
     [ObservableProperty]
-    public bool _enableDeveloperMode = false;
+    public bool _enableTestMode = false;
     [ObservableProperty]
     public bool _hideIpAddress = true;
     [ObservableProperty]

--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -498,10 +498,6 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
                 availableVersions[i].DowngradeRequired = true;
                 availableVersions[i].IsAvailable = true;
             }
-
-#if DEBUG
-            availableVersions[i].IsAvailable = true;
-#endif
         }
         return availableVersions;
     }

--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -265,11 +265,11 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
                         SitVersion = release.Name,
                     };
 
-                    if (release.Prerelease && _configService.Config.EnableDeveloperMode)
+                    if (release.Prerelease && _configService.Config.EnableTestMode)
                     {
                         result.Add(sitVersion);
                     }
-                    else if (!release.Prerelease && !_configService.Config.EnableDeveloperMode)
+                    else if (!release.Prerelease && !_configService.Config.EnableTestMode)
                     {
                         result.Add(sitVersion);
                     }
@@ -415,11 +415,11 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
                         release.TagName = $"{release.Name} - Tarkov Version: {releasePatch}";
                         release.Body = releasePatch;
 
-                        if (release.Prerelease && _configService.Config.EnableDeveloperMode)
+                        if (release.Prerelease && _configService.Config.EnableTestMode)
                         {
                             result.Add(release);
                         }
-                        else if (!release.Prerelease && !_configService.Config.EnableDeveloperMode)
+                        else if (!release.Prerelease && !_configService.Config.EnableTestMode)
                         {
                             result.Add(release);
                         }

--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -251,12 +251,6 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
         {
             foreach (GithubRelease release in githubReleases)
             {
-                // If this is a prerelease build and the user hasn't eneabled developer mode then we want to skip adding this to the list.
-                if (release.Prerelease && !_configService.Config.EnableDeveloperMode)
-                {
-                    continue;
-                }
-
                 Match match = SITReleaseVersionRegex().Match(release.Body);
                 if (match.Success)
                 {
@@ -271,7 +265,14 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
                         SitVersion = release.Name,
                     };
 
-                    result.Add(sitVersion);
+                    if (release.Prerelease && _configService.Config.EnableDeveloperMode)
+                    {
+                        result.Add(sitVersion);
+                    }
+                    else if (!release.Prerelease && !_configService.Config.EnableDeveloperMode)
+                    {
+                        result.Add(sitVersion);
+                    }
                 }
                 else
                 {
@@ -397,12 +398,6 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
         {
             foreach (GithubRelease release in githubReleases)
             {
-                // If this is a prerelease build and the user hasn't eneabled developer mode then we want to skip adding this to the list.
-                if (release.Prerelease && !_configService.Config.EnableDeveloperMode)
-                {
-                    continue;
-                }
-
                 // Check there is an asset available for this OS
                 string fileExtention = ".zip";
                 if (OperatingSystem.IsLinux())
@@ -419,7 +414,15 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
                         string releasePatch = match.Value.Replace("This server version works with version ", "");
                         release.TagName = $"{release.Name} - Tarkov Version: {releasePatch}";
                         release.Body = releasePatch;
-                        result.Add(release);
+
+                        if (release.Prerelease && _configService.Config.EnableDeveloperMode)
+                        {
+                            result.Add(release);
+                        }
+                        else if (!release.Prerelease && !_configService.Config.EnableDeveloperMode)
+                        {
+                            result.Add(release);
+                        }
                     }
                     else
                     {
@@ -496,11 +499,9 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
                 availableVersions[i].IsAvailable = true;
             }
 
-            // If user is a developer just enable the version anyway
-            if (_configService.Config.EnableDeveloperMode)
-            {
-                availableVersions[i].IsAvailable = true;
-            }
+#if DEBUG
+            availableVersions[i].IsAvailable = true;
+#endif
         }
         return availableVersions;
     }

--- a/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
@@ -137,7 +137,7 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
             if (!string.IsNullOrEmpty(_configService.Config.SitVersion))
             {
                 // Don't filter down the available versions if user has enabled developer mode.
-                if (!_configService.Config.EnableDeveloperMode)
+                if (!_configService.Config.EnableTestMode)
                 {
                     availableVersions = availableVersions.Where(x =>
                     {

--- a/SIT.Manager/ViewModels/MainViewModel.cs
+++ b/SIT.Manager/ViewModels/MainViewModel.cs
@@ -37,7 +37,7 @@ public partial class MainViewModel : ObservableRecipient, IRecipient<Installatio
     private ActionNotification? _actionPanelNotification = new(string.Empty, 0, false);
 
     [ObservableProperty]
-    private bool _isDevloperModeEnabled = false;
+    private bool _isTestModeEnabled = false;
 
     [ObservableProperty]
     private bool _updateAvailable = false;
@@ -110,7 +110,7 @@ public partial class MainViewModel : ObservableRecipient, IRecipient<Installatio
 
     private void ManagerConfigService_ConfigChanged(object? sender, ManagerConfig e)
     {
-        IsDevloperModeEnabled = e.EnableDeveloperMode;
+        IsTestModeEnabled = e.EnableTestMode;
     }
 
     private async Task CheckForUpdate()

--- a/SIT.Manager/ViewModels/ModsPageViewModel.cs
+++ b/SIT.Manager/ViewModels/ModsPageViewModel.cs
@@ -173,9 +173,9 @@ public partial class ModsPageViewModel : ObservableRecipient
 
     protected override async void OnActivated()
     {
-        // Developer mod enabled but we are still trying to go to the mods page so 
+        // Test mode enabled but we are still trying to go to the mods page so 
         // force them to a different page
-        if (_managerConfigService.Config.EnableDeveloperMode)
+        if (_managerConfigService.Config.EnableTestMode)
         {
             PageNavigation pageNavigation = new(typeof(PlayPage), false);
             WeakReferenceMessenger.Default.Send(new PageNavigationMessage(pageNavigation));

--- a/SIT.Manager/ViewModels/Settings/LauncherViewModel.cs
+++ b/SIT.Manager/ViewModels/Settings/LauncherViewModel.cs
@@ -21,7 +21,7 @@ public partial class LauncherViewModel(IManagerConfigService configService,
     private readonly FluentAvaloniaTheme? faTheme = Application.Current?.Styles.OfType<FluentAvaloniaTheme>().FirstOrDefault();
 
     [ObservableProperty]
-    private bool _isDeveloperModeEnabled = false;
+    private bool _isTestModeEnabled = false;
 
     [ObservableProperty]
     private List<CultureInfo> _availableLocalizations = localizationService.GetAvailableLocalizations();
@@ -45,7 +45,7 @@ public partial class LauncherViewModel(IManagerConfigService configService,
         base.OnActivated();
 
         CurrentLocalization = AvailableLocalizations.FirstOrDefault(x => x.Name == Config.CurrentLanguageSelected, _localizationService.DefaultLocale);
-        IsDeveloperModeEnabled = Config.EnableDeveloperMode;
+        IsTestModeEnabled = Config.EnableTestMode;
 
         Config.PropertyChanged += Config_PropertyChanged;
     }
@@ -65,9 +65,9 @@ public partial class LauncherViewModel(IManagerConfigService configService,
         }
     }
 
-    async partial void OnIsDeveloperModeEnabledChanged(bool value)
+    async partial void OnIsTestModeEnabledChanged(bool value)
     {
-        // If developer mode is enabled then we want to check that there's no mods we don't approve of currently installed.
+        // If test mode is enabled then we want to check that there's no mods we don't approve of currently installed.
         if (value)
         {
             List<string> installedMods = _configsService.Config.InstalledMods.Keys.ToList();
@@ -84,12 +84,12 @@ public partial class LauncherViewModel(IManagerConfigService configService,
             }
             else
             {
-                Config.EnableDeveloperMode = value;
+                Config.EnableTestMode = value;
             }
         }
         else
         {
-            Config.EnableDeveloperMode = value;
+            Config.EnableTestMode = value;
         }
     }
 }

--- a/SIT.Manager/Views/MainView.axaml
+++ b/SIT.Manager/Views/MainView.axaml
@@ -92,7 +92,7 @@
 									   Tag="SIT.Manager.Views.ServerPage" 
 									   ToolTip.Tip="{DynamicResource ServerTitleToolTip}"/>
 				<ui:NavigationViewItem IconSource="Library" 
-									   IsVisible="{Binding !IsDevloperModeEnabled}"
+									   IsVisible="{Binding !IsTestModeEnabled}"
 									   IsEnabled="{Binding !IsInstallRunning}"
 									   Content="{DynamicResource ModsTitle}" 
 									   Tag="SIT.Manager.Views.ModsPage" 

--- a/SIT.Manager/Views/Settings/LauncherView.axaml
+++ b/SIT.Manager/Views/Settings/LauncherView.axaml
@@ -18,9 +18,9 @@
 			<CheckBox Content="{DynamicResource SettingsHideIpAddressTitle}"
 					  ToolTip.Tip="{DynamicResource SettingsHideIpAddressToolTip}"
 					  IsChecked="{Binding Config.HideIpAddress, Mode=TwoWay}"/>
-			<CheckBox Content="Show SIT Test Versions Only"
-					  ToolTip.Tip="{DynamicResource SettingsEnableDeveloperModeToolTip}"
-					  IsChecked="{Binding IsDeveloperModeEnabled, Mode=TwoWay}"/>
+			<CheckBox Content="{DynamicResource SettingsEnableTestMode}"
+					  ToolTip.Tip="{DynamicResource SettingsEnableTestModeToolTip}"
+					  IsChecked="{Binding IsTestModeEnabled, Mode=TwoWay}"/>
 			<Grid ColumnDefinitions="auto, *">
 				<TextBlock Text="{DynamicResource SettingsLanguageTitle}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
 				<ComboBox Margin="5,0,0,0" 

--- a/SIT.Manager/Views/Settings/LauncherView.axaml
+++ b/SIT.Manager/Views/Settings/LauncherView.axaml
@@ -18,7 +18,7 @@
 			<CheckBox Content="{DynamicResource SettingsHideIpAddressTitle}"
 					  ToolTip.Tip="{DynamicResource SettingsHideIpAddressToolTip}"
 					  IsChecked="{Binding Config.HideIpAddress, Mode=TwoWay}"/>
-			<CheckBox Content="{DynamicResource SettingsEnableDeveloperMode}"
+			<CheckBox Content="Show SIT Test Versions Only"
 					  ToolTip.Tip="{DynamicResource SettingsEnableDeveloperModeToolTip}"
 					  IsChecked="{Binding IsDeveloperModeEnabled, Mode=TwoWay}"/>
 			<Grid ColumnDefinitions="auto, *">


### PR DESCRIPTION
Convert the developer mode we created a little while ago in the launcher to a test mode which will only show prerelease builds of SIT client to users. So that when we want people to test a release of SIT they can enable that and install it then, otherwise they will only have normal full releases of SIT.