### PR TITLE
Fix Installer service not supporting zip changes

### DIFF
--- a/SIT.Manager/Services/Install/InstallerService.cs
+++ b/SIT.Manager/Services/Install/InstallerService.cs
@@ -698,14 +698,14 @@ public partial class InstallerService(IBarNotificationService barNotificationSer
             }
 
             // Find Assembly-CSharp file
-            var assemblyCSharpFiles = Directory.GetFiles(coreFilesPath, "Assembly-CSharp.dll");
+            var assemblyCSharpFiles = Directory.GetFiles(coreFilesPath, "*Assembly-CSharp.dll");
             if (assemblyCSharpFiles.Length == 0)
                 throw new IndexOutOfRangeException("No Assembly-CSharp found in download!");
             if (assemblyCSharpFiles.Length > 1)
                 throw new IndexOutOfRangeException("There are more than one Assembly-CSharp files found!");
 
             // Find StayInTarkov.dll
-            var sitFiles = Directory.GetFiles(coreFilesPath, "StayInTarkov.dll");
+            var sitFiles = Directory.GetFiles(coreFilesPath, "*StayInTarkov.dll");
             if (sitFiles.Length == 0)
                 throw new IndexOutOfRangeException("No StayInTarkov.dll found in download!");
             if (sitFiles.Length > 1)


### PR DESCRIPTION
The installer service was hardcoded to use an exact folder structure when downloading StayInTarkov-Release.zip from GitHub. This resolves the issue and searches for the files extracted from the zip and then installs them.