### PR TITLE
Move the manager version string to be always visible

### DIFF
--- a/SIT.Manager/App.axaml.cs
+++ b/SIT.Manager/App.axaml.cs
@@ -213,10 +213,7 @@ public sealed partial class App : Application
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewPlatform)
         {
-            singleViewPlatform.MainView = new MainView
-            {
-                DataContext = Current.Services.GetService<MainViewModel>()
-            };
+            singleViewPlatform.MainView = new MainView();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -108,7 +108,6 @@
 	<system:String x:Key="SettingsServerConsoleTitle">Server Console</system:String>
 	<system:String x:Key="SettingsServerConsoleFontFamilyTitle">Font Family:</system:String>
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">Font Color:</system:String>
-	<system:String x:Key="SettingsManagerVersionTitle">Manager Version:</system:String>
 
 	<!-- EftView -->
 	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT Install Path:</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -113,7 +113,6 @@
 	<system:String x:Key="SettingsServerConsoleTitle">Консоль Сервера</system:String>
 	<system:String x:Key="SettingsServerConsoleFontFamilyTitle">Шрифт:</system:String>
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">Цвет Шрифта:</system:String>
-	<system:String x:Key="SettingsManagerVersionTitle">Версия Менеджера (Лаунчера):</system:String>
 
 	<!-- EftView -->
 	<system:String x:Key="EftViewBsgEftInstallPath">Путь установки BSG EFT:</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -117,7 +117,6 @@
 	<system:String x:Key="SettingsServerConsoleTitle">Консоль Сервера</system:String>
 	<system:String x:Key="SettingsServerConsoleFontFamilyTitle">Шрифт:</system:String>
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">Колір Шрифту:</system:String>
-	<system:String x:Key="SettingsManagerVersionTitle">Версія Менеджера (Лаунчера):</system:String>
 
 	<!-- EftView -->
 	<system:String x:Key="EftViewBsgEftInstallPath">Шлях встановлення BSG EFT:</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -113,7 +113,6 @@
 	<system:String x:Key="SettingsServerConsoleTitle">服务器控制台</system:String>
 	<system:String x:Key="SettingsServerConsoleFontFamilyTitle">字体:</system:String>
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">字体颜色:</system:String>
-	<system:String x:Key="SettingsManagerVersionTitle">当前 SIT Manager 版本:</system:String>
 
 	<!-- EftView -->
 	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT 安装路径:</system:String>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -113,7 +113,6 @@
 	<system:String x:Key="SettingsServerConsoleTitle">伺服器控制臺</system:String>
 	<system:String x:Key="SettingsServerConsoleFontFamilyTitle">字型:</system:String>
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">字型顏色:</system:String>
-	<system:String x:Key="SettingsManagerVersionTitle">當前 SIT Manager 版本:</system:String>
 
 	<!-- EftView -->
 	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT 安裝路徑:</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -113,7 +113,6 @@
 	<system:String x:Key="SettingsServerConsoleTitle">伺服器控制臺</system:String>
 	<system:String x:Key="SettingsServerConsoleFontFamilyTitle">字體:</system:String>
 	<system:String x:Key="SettingsServerConsoleFontColorTitle">字體顏色:</system:String>
-	<system:String x:Key="SettingsManagerVersionTitle">當前 SIT Manager 版本:</system:String>
 
 	<!-- EftView -->
 	<system:String x:Key="EftViewBsgEftInstallPath">BSG EFT 安裝路徑:</system:String>

--- a/SIT.Manager/ViewModels/MainViewModel.cs
+++ b/SIT.Manager/ViewModels/MainViewModel.cs
@@ -19,6 +19,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace SIT.Manager.ViewModels;
@@ -66,6 +67,9 @@ public partial class MainViewModel : ObservableRecipient, IRecipient<Installatio
 
     [ObservableProperty]
     public ReadOnlyCollection<NavigationItem> _mainNavigationItems;
+
+    [ObservableProperty]
+    private string _managerVersionString = $"v{Assembly.GetEntryAssembly()?.GetName().Version?.ToString()}";
 
     public ObservableCollection<BarNotification> BarNotifications { get; } = [];
 

--- a/SIT.Manager/ViewModels/SettingsPageViewModel.cs
+++ b/SIT.Manager/ViewModels/SettingsPageViewModel.cs
@@ -1,16 +1,10 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
-using System.Linq;
-using System.Reflection;
 
 namespace SIT.Manager.ViewModels;
 
 public partial class SettingsPageViewModel : ObservableObject
 {
-    [ObservableProperty]
-    private string _managerVersionString;
-
     public SettingsPageViewModel()
     {
-        ManagerVersionString = Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "N/A";
     }
 }

--- a/SIT.Manager/Views/MainView.axaml
+++ b/SIT.Manager/Views/MainView.axaml
@@ -73,7 +73,7 @@
 				   OpenPaneLength="166"
 				   Grid.Row="1">
 			<SplitView.Pane>
-				<Grid RowDefinitions="Auto, *, Auto"
+				<Grid RowDefinitions="Auto, *, Auto, Auto"
 					  Background="#080808">
 					<ListBox Grid.Row="0"
 							 IsEnabled="{Binding !IsInstallRunning}"
@@ -91,7 +91,13 @@
 							 ItemsSource="{Binding FooterNavigationItems}"
 							 SelectedItem="{Binding SelectedFooterNavigationItem}"
 							 Classes="NavigationMenu"
-							 Margin="0,0,0,16"/>
+							 Margin="0"/>
+
+					<SelectableTextBlock Margin="2,4,0,2"
+										 Grid.Row="3"
+										 FontSize="11"
+										 Opacity="0.6"
+										 Text="{Binding ManagerVersionString}"/>
 				</Grid>
 			</SplitView.Pane>
 

--- a/SIT.Manager/Views/MainView.axaml.cs
+++ b/SIT.Manager/Views/MainView.axaml.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.DependencyInjection;
 using SIT.Manager.Controls;
+using SIT.Manager.ViewModels;
 
 namespace SIT.Manager.Views;
 
@@ -7,5 +9,6 @@ public partial class MainView : ActivatableUserControl
     public MainView()
     {
         InitializeComponent();
+        DataContext = App.Current.Services.GetService<MainViewModel>();
     }
 }

--- a/SIT.Manager/Views/SettingsPage.axaml
+++ b/SIT.Manager/Views/SettingsPage.axaml
@@ -28,10 +28,5 @@
 				<sv:LinuxView/>
 			</TabItem>
 		</TabControl>
-
-		<StackPanel Margin="0,5" Orientation="Horizontal" Grid.Row="1">
-			<TextBlock Margin="10" Text="{DynamicResource SettingsManagerVersionTitle}"/>
-			<SelectableTextBlock Text="{Binding ManagerVersionString}" VerticalAlignment="Center" Padding="5"/>
-		</StackPanel>
 	</Grid>
 </UserControl>


### PR DESCRIPTION
Moves the manager version string from where it currently is on the settings page as shown below to be always visible but tucked away in the bottom left corner.

Before;
![image](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/112902041/cd037bd8-3221-48ec-b47d-ac1affe59583)

After:
![image](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/112902041/66faff63-112e-415f-a215-cf3163865d08)
