### PR TITLE
Automagically install config manager always

### DIFF
--- a/SIT.Manager/Interfaces/IModService.cs
+++ b/SIT.Manager/Interfaces/IModService.cs
@@ -30,13 +30,19 @@ public interface IModService
     /// <returns></returns>
     Task DownloadModsCollection();
     /// <summary>
+    /// Downloads (unless it's cached already) and installs the latest configuration manager from GitHub
+    /// </summary>
+    /// <param name="targetPath">Base location of where the EFT install is to put the mod</param>
+    /// <returns>True if it was successfully installed; otherwise False</returns>
+    Task<bool> InstallConfigurationManager(string targetPath);
+    /// <summary>
     /// Install a mod into the given target location
     /// </summary>
     /// <param name="targetPath">Base location of where the EFT install is to put the mod</param>
     /// <param name="mod">The meta data for the mod we want to install</param>
     /// <param name="suppressNotification">Supress notifications of the mods installation status</param>
     /// <param name="suppressCompatibilityWarning">Supress the warning about a mods compatibility</param>
-    /// <returns></returns>
+    /// <returns>True if it was successfully installed; otherwise False</returns>
     Task<bool> InstallMod(string targetPath, ModInfo mod, bool suppressNotification = false, bool suppressCompatibilityWarning = false);
     /// <summary>
     /// Load the master list of mods into memory so we know what mods are available

--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -367,8 +367,6 @@
 	<system:String x:Key="ConfigureSitViewEFTPathWarningNoPath">Currently using the BSG EFT install location please install EFT to a different location to avoid any possible issues with SIT</system:String>
 	<system:String x:Key="ConfigureSitViewMirrorSelectionTitle">Select the mirror to use:</system:String>
 	<system:String x:Key="ConfigureSitViewVersionSelectionTitle">Version to install:</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsTitle">Recommended Mods</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsDescription">Choose from the available mods which we recommend you install alongside SIT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTip">Import Live Game Graphic, Audio, and Control settings to SIT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTitle">Import EFT Settings to SIT</system:String>
 

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -371,8 +371,6 @@
 	<system:String x:Key="ConfigureSitViewEFTPathWarningNoPath">В настоящее время используется местоположение установки BSG EFT. Пожалуйста, установите EFT в другое место, чтобы избежать возможных проблем с SIT</system:String>
 	<system:String x:Key="ConfigureSitViewMirrorSelectionTitle">Выберите зеркало для использования:</system:String>
 	<system:String x:Key="ConfigureSitViewVersionSelectionTitle">Версия для установки:</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsTitle">Рекомендуемые моды</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsDescription">Выберите из доступных модов, которые мы рекомендуем вам установить вместе с SIT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTip">Импортировать в SIT настройки из EFT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTitle">Импортировать настройки EFT в SIT</system:String>
 

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -372,8 +372,6 @@
 	<system:String x:Key="ConfigureSitViewEFTPathWarningNoPath">Наразі використовується місце встановлення BSG EFT. Будь ласка, встановіть EFT в інше місце, щоб уникнути можливих проблем з SIT</system:String>
 	<system:String x:Key="ConfigureSitViewMirrorSelectionTitle">Виберіть дзеркало для використання:</system:String>
 	<system:String x:Key="ConfigureSitViewVersionSelectionTitle">Версія для установки:</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsTitle">Рекомендовані модифікації</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsDescription">Виберіть з доступних модів, які ми рекомендуємо вам встановити разом з SIT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTip">Імпортувати налаштування графіки, звуку та керування живої гри до SIT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTitle">Імпортувати налаштування EFT до SIT</system:String>
 

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -372,8 +372,6 @@
 	<system:String x:Key="ConfigureSitViewEFTPathWarningNoPath">当前使用 BSG EFT 的安装位置。请将 EFT 安装到其他位置以避免与 SIT 的潜在问题</system:String>
 	<system:String x:Key="ConfigureSitViewMirrorSelectionTitle">选择要使用的镜像：</system:String>
 	<system:String x:Key="ConfigureSitViewVersionSelectionTitle">要安装的版本：</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsTitle">推荐 Mod</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsDescription">从可用的 Mod 中选择我们建议您与 SIT 一起安装的内容</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTip">将现场游戏的图形、音频和控制设置导入到 SIT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTitle">将 EFT 设置导入到 SIT</system:String>
 

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -371,8 +371,6 @@
 	<system:String x:Key="ConfigureSitViewEFTPathWarningNoPath">目前使用 BSG EFT 的安裝位置。請將 EFT 安裝到其他位置以避免與 SIT 的潛在問題</system:String>
 	<system:String x:Key="ConfigureSitViewMirrorSelectionTitle">選擇要使用的鏡像：</system:String>
 	<system:String x:Key="ConfigureSitViewVersionSelectionTitle">要安裝的版本：</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsTitle">推薦 Mod</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsDescription">從可用的 Mod 中選擇我們建議您與 SIT 一起安裝的內容</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTip">將現場遊戲的圖形、音頻和控制設置導入到 SIT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTitle">將 EFT 設置導入到 SIT</system:String>
 

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -372,8 +372,6 @@
 	<system:String x:Key="ConfigureSitViewEFTPathWarningNoPath">目前使用 BSG EFT 的安裝位置。請將 EFT 安裝到其他位置以避免與 SIT 的潛在問題</system:String>
 	<system:String x:Key="ConfigureSitViewMirrorSelectionTitle">選擇要使用的鏡像：</system:String>
 	<system:String x:Key="ConfigureSitViewVersionSelectionTitle">要安裝的版本：</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsTitle">推薦 Mod</system:String>
-	<system:String x:Key="ConfigureSitViewRecommendedModsDescription">從可用的 Mod 中選擇我們建議您與 SIT 一起安裝的內容</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTip">將現場遊戲的圖形、音頻和控制設置導入到 SIT</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsCheckboxTitle">將 EFT 設置導入到 SIT</system:String>
 

--- a/SIT.Manager/Models/Installation/InstallProcessState.cs
+++ b/SIT.Manager/Models/Installation/InstallProcessState.cs
@@ -1,6 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using SIT.Manager.Models.Github;
-using System.Collections.Generic;
 
 namespace SIT.Manager.Models.Installation;
 
@@ -11,8 +10,6 @@ public partial class InstallProcessState : ObservableObject
     private RequestedInstallOperation _requestedInstallOperation = RequestedInstallOperation.None;
     [ObservableProperty]
     private GithubRelease _requestedVersion = new();
-    [ObservableProperty]
-    public List<ModInfo> _requestedMods = [];
 
     // EFT Install Settings
     [ObservableProperty]

--- a/SIT.Manager/Services/ModService.cs
+++ b/SIT.Manager/Services/ModService.cs
@@ -5,26 +5,35 @@ using Microsoft.Extensions.Logging;
 using SIT.Manager.Interfaces;
 using SIT.Manager.Models;
 using SIT.Manager.Models.Config;
+using SIT.Manager.Models.Github;
+using SIT.Manager.Services.Caching;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace SIT.Manager.Services;
 
 public class ModService(IBarNotificationService barNotificationService,
+                        ICachingService cachingService,
                         IFileService filesService,
                         ILocalizationService localizationService,
                         IManagerConfigService configService,
+                        HttpClient httpClient,
                         ILogger<ModService> logger) : IModService
 {
+    private const string BEPINEX_CONFIGURATION_MANAGER_RELEASE_URL = "https://api.github.com/repos/BepInEx/BepInEx.ConfigurationManager/releases/latest";
+    private const string CONFIGURATION_MANAGER_ZIP_CACHE_KEY = "configuration-manager-zip";
     private const string MOD_COLLECTION_URL = "https://github.com/stayintarkov/SIT-Mod-Ports/releases/latest/download/SIT.Mod.Ports.Collection.zip";
 
     private readonly IBarNotificationService _barNotificationService = barNotificationService;
+    private readonly ICachingService _cachingService = cachingService;
     private readonly IFileService _filesService = filesService;
     private readonly IManagerConfigService _configService = configService;
+    private readonly HttpClient _httpClient = httpClient;
     private readonly ILogger<ModService> _logger = logger;
     private readonly ILocalizationService _localizationService = localizationService;
 
@@ -137,6 +146,75 @@ public class ModService(IBarNotificationService barNotificationService,
         }
 
         _barNotificationService.ShowSuccess(_localizationService.TranslateSource("ModServiceUpdatedModsTitle"), _localizationService.TranslateSource("ModServiceUpdatedModsDescription", $"{outdatedMods.Count}"));
+    }
+
+    public async Task<bool> InstallConfigurationManager(string targetPath)
+    {
+        if (string.IsNullOrEmpty(targetPath))
+        {
+            throw new ArgumentException("Parameter can't be null or empty", nameof(targetPath));
+        }
+
+        CacheValue<byte[]> configurationManagerDll = await _cachingService.OnDisk.GetOrComputeAsync(CONFIGURATION_MANAGER_ZIP_CACHE_KEY,
+            async (key) =>
+            {
+                string latestReleaseJson = await _httpClient.GetStringAsync(BEPINEX_CONFIGURATION_MANAGER_RELEASE_URL).ConfigureAwait(false);
+                GithubRelease? latestRelease = JsonSerializer.Deserialize<GithubRelease>(latestReleaseJson);
+
+                if (latestRelease != null)
+                {
+                    string assetDownloadUrl = string.Empty;
+                    foreach (GithubAsset asset in latestRelease.Assets)
+                    {
+                        if (asset.Name.Contains("BepInEx5"))
+                        {
+                            assetDownloadUrl = asset.BrowserDownloadUrl;
+                        }
+                    }
+
+                    if (string.IsNullOrEmpty(assetDownloadUrl))
+                    {
+                        throw new UriFormatException("No download url available for Configuration manager");
+                    }
+
+                    string tmpZipFilePath = Path.GetTempFileName();
+                    bool downloadSuccess = await _filesService.DownloadFile(Path.GetFileName(tmpZipFilePath), Path.GetDirectoryName(tmpZipFilePath) ?? string.Empty, assetDownloadUrl, false).ConfigureAwait(false);
+                    if (downloadSuccess)
+                    {
+                        string extractedZipPath = Path.GetTempFileName();
+                        if (File.Exists(extractedZipPath))
+                        {
+                            File.Delete(extractedZipPath);
+                        }
+                        await _filesService.ExtractArchive(tmpZipFilePath, extractedZipPath).ConfigureAwait(false);
+
+                        string[] files = Directory.GetFiles(extractedZipPath, "ConfigurationManager.dll", new EnumerationOptions() { RecurseSubdirectories = true });
+                        if (files.Length == 1)
+                        {
+                            return await File.ReadAllBytesAsync(files[0]).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            throw new FileNotFoundException("Found too many or too few Configuration manager dlls in extraction target");
+                        }
+                    }
+                    else
+                    {
+                        throw new IOException("Failed to download the latest configuration manager from GitHub");
+                    }
+                }
+                throw new FileNotFoundException("Failed to get the latest release for Configuration Manager");
+            }, TimeSpan.FromDays(1));
+
+        byte[] configurationManagerBytes = configurationManagerDll.Value ?? [];
+        if (configurationManagerBytes.Length == 0)
+        {
+            throw new FileNotFoundException("Failed find and install Configuration Manager");
+        }
+
+        string targetInstallLocation = Path.Combine(targetPath, "BepInEx", "plugins");
+        await File.WriteAllBytesAsync(targetInstallLocation, configurationManagerBytes).ConfigureAwait(false);
+        return true;
     }
 
     public async Task<bool> InstallMod(string targetPath, ModInfo mod, bool suppressNotification = false, bool suppressCompatibilityWarning = false)

--- a/SIT.Manager/Services/ModService.cs
+++ b/SIT.Manager/Services/ModService.cs
@@ -26,7 +26,7 @@ public class ModService(IBarNotificationService barNotificationService,
                         ILogger<ModService> logger) : IModService
 {
     private const string BEPINEX_CONFIGURATION_MANAGER_RELEASE_URL = "https://api.github.com/repos/BepInEx/BepInEx.ConfigurationManager/releases/latest";
-    private const string CONFIGURATION_MANAGER_ZIP_CACHE_KEY = "configuration-manager-zip";
+    private const string CONFIGURATION_MANAGER_ZIP_CACHE_KEY = "configuration-manager-dll";
     private const string MOD_COLLECTION_URL = "https://github.com/stayintarkov/SIT-Mod-Ports/releases/latest/download/SIT.Mod.Ports.Collection.zip";
 
     private readonly IBarNotificationService _barNotificationService = barNotificationService;
@@ -212,7 +212,7 @@ public class ModService(IBarNotificationService barNotificationService,
             throw new FileNotFoundException("Failed find and install Configuration Manager");
         }
 
-        string targetInstallLocation = Path.Combine(targetPath, "BepInEx", "plugins");
+        string targetInstallLocation = Path.Combine(targetPath, "BepInEx", "plugins", "ConfigurationManager.dll");
         await File.WriteAllBytesAsync(targetInstallLocation, configurationManagerBytes).ConfigureAwait(false);
         return true;
     }

--- a/SIT.Manager/ViewModels/Installation/InstallViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/InstallViewModel.cs
@@ -2,7 +2,6 @@
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
 using SIT.Manager.Interfaces;
-using SIT.Manager.Models;
 using SIT.Manager.Models.Installation;
 using System;
 using System.Threading.Tasks;
@@ -44,10 +43,8 @@ public partial class InstallViewModel : InstallationViewModelBase
 
     private int CalculateAdditionalInstallSteps()
     {
-        int additionalSteps = 0;
-
-        // Count each mod install as an extra step so we adjust the progress bar scaling accordingly.
-        additionalSteps += CurrentInstallProcessState.RequestedMods.Count;
+        // We start with 1 additional step as we install BepInEx Configuration Manager
+        int additionalSteps = 1;
 
         // Add an extra step if we are copying the user's eft settings.
         if (CurrentInstallProcessState.CopyEftSettings)
@@ -113,14 +110,9 @@ public partial class InstallViewModel : InstallationViewModelBase
             UpdateInstallProgress();
         }
 
-        foreach (ModInfo mod in CurrentInstallProcessState.RequestedMods)
-        {
-            await _modService.InstallMod(CurrentInstallProcessState.EftInstallPath, mod, true, true);
-
-            // We copied settings so remove a step and force a progress bar recalculation
-            _installSteps--;
-            UpdateInstallProgress();
-        }
+        await _modService.InstallConfigurationManager(CurrentInstallProcessState.EftInstallPath);
+        _installSteps--;
+        UpdateInstallProgress();
     }
 
     protected override async void OnActivated()

--- a/SIT.Manager/ViewModels/ModsPageViewModel.cs
+++ b/SIT.Manager/ViewModels/ModsPageViewModel.cs
@@ -173,6 +173,8 @@ public partial class ModsPageViewModel : ObservableRecipient
 
     protected override async void OnActivated()
     {
+        await _modService.InstallConfigurationManager("testFolder");
+
         // Test mode enabled but we are still trying to go to the mods page so 
         // force them to a different page
         if (_managerConfigService.Config.EnableTestMode)

--- a/SIT.Manager/ViewModels/ModsPageViewModel.cs
+++ b/SIT.Manager/ViewModels/ModsPageViewModel.cs
@@ -173,8 +173,6 @@ public partial class ModsPageViewModel : ObservableRecipient
 
     protected override async void OnActivated()
     {
-        await _modService.InstallConfigurationManager("testFolder");
-
         // Test mode enabled but we are still trying to go to the mods page so 
         // force them to a different page
         if (_managerConfigService.Config.EnableTestMode)

--- a/SIT.Manager/Views/Installation/ConfigureSitView.axaml
+++ b/SIT.Manager/Views/Installation/ConfigureSitView.axaml
@@ -140,59 +140,20 @@
 				</Border>
 			</StackPanel>
 
-			<StackPanel IsVisible="{Binding HasRecommendedModsAvailable}">
-				<TextBlock Text="{DynamicResource ConfigureSitViewRecommendedModsTitle}" Classes="FrameHeading"/>
-				<Border Classes="StandardFrame">
-					<StackPanel>
-						<StackPanel IsVisible="{Binding !IsModsSelectionLoading}">
-							<TextBlock Text="{DynamicResource ConfigureSitViewRecommendedModsDescription}"
-									   TextWrapping="Wrap"/>
-							<ListBox ItemsSource="{Binding Mods}"
-									 Margin="0,4,0,0"
-									 SelectedItems="{Binding CurrentInstallProcessState.RequestedMods}"
-									 SelectionMode="Multiple,Toggle">
-								<ListBox.ItemTemplate>
-									<DataTemplate>
-										<Grid>
-											<TextBlock>
-												<Run Text="{Binding Name}"/>
-												<Run Text=" - "/>
-												<Run Text="{Binding ModVersion}"/>
-											</TextBlock>
-										</Grid>
-									</DataTemplate>
-								</ListBox.ItemTemplate>
-							</ListBox>
-						</StackPanel>
-
-						<StackPanel IsVisible="{Binding IsModsSelectionLoading}">
-							<TextBlock HorizontalAlignment="Center"
-									   Text="{DynamicResource ConfigureSitViewLoadingVersionSelectionText}"/>
-							<controls:LoadingSpinner Width="64"
-												 Height="{Binding $self.Width}"
-												 Margin="0,8,0,0"
-												 HorizontalAlignment="Center"
-												 VerticalAlignment="Center"
-												 Foreground="{DynamicResource TextControlForeground}"
-												 StrokeWidth="8"/>
-						</StackPanel>
-					</StackPanel>
-				</Border>
-				<TextBlock Text="{DynamicResource ConfigureViewPersonalizationOptions}" Classes="FrameHeading"/>
-				<Border Classes="StandardFrame">
-					<CheckBox HorizontalAlignment="Left"
-							  Margin="8,0,0,0"
-							  ToolTip.Tip="{DynamicResource ConfigureSitViewEFTSettingsCheckboxTip}"
-							  IsChecked="{Binding CurrentInstallProcessState.CopyEftSettings}">
-						<CheckBox.Content>
-							<Grid ColumnDefinitions="Auto,*">
-								<ui:SymbolIcon Grid.Column="0" Symbol="Settings" Margin="0,0,0,0"/>
-								<TextBlock Grid.Column="1" Text="{DynamicResource ConfigureSitViewEFTSettingsCheckboxTitle}" Margin="5,0,0,0" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
-							</Grid>
-						</CheckBox.Content>
-					</CheckBox>
-				</Border>
-			</StackPanel>
+			<TextBlock Text="{DynamicResource ConfigureViewPersonalizationOptions}" Classes="FrameHeading"/>
+			<Border Classes="StandardFrame">
+				<CheckBox HorizontalAlignment="Left"
+						  Margin="8,0,0,0"
+						  ToolTip.Tip="{DynamicResource ConfigureSitViewEFTSettingsCheckboxTip}"
+						  IsChecked="{Binding CurrentInstallProcessState.CopyEftSettings}">
+					<CheckBox.Content>
+						<Grid ColumnDefinitions="Auto,*">
+							<ui:SymbolIcon Grid.Column="0" Symbol="Settings" Margin="0,0,0,0"/>
+							<TextBlock Grid.Column="1" Text="{DynamicResource ConfigureSitViewEFTSettingsCheckboxTitle}" Margin="5,0,0,0" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+						</Grid>
+					</CheckBox.Content>
+				</CheckBox>
+			</Border>
 
 			<Grid ColumnDefinitions="*, *"
 				  Margin="4,8">


### PR DESCRIPTION
Rather than having the option to install configuration manager now we just do it, but also cache the downloaded dll for a day just in case they run multiple installs this'll help prevent hitting that GitHub api rate limit.