### PR TITLE
Various Fixes

### DIFF
--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -376,6 +376,7 @@
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorTitle">Location Selection Error</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorDescription">You've selected the same folder as the BSG install of EFT, please choose a different location to install SIT to</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionSPTErrorDescription">You've selected the same folder as an existing SPT install, please choose a different location to install SIT to</system:String>
+	<system:String x:Key="ConfigureSitViewModelLocationSelectionOneDriveErrorDescription">We think you've selected your 'OneDrive' folder which is known to cause issue, please choose a different location to install SIT to</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorOk">Ok</system:String>
 
 	<!-- Install - Install View -->

--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -359,7 +359,8 @@
 
 	<!-- Install - Configure Sit View -->
 	<system:String x:Key="ConfigureSitViewLoadingVersionSelectionText">Working out available SIT versions please wait...</system:String>
-	<system:String x:Key="ConfigureSitViewVersionSelectionErrorMessage">Unable to determine available SIT versions...</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionNoneAvailableErrorMessage">No version of SIT available for your current version of EFT. Please make sure your EFT is up to date</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionGenericErrorMessage">Unable to determine available SIT versions...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTChangeInstallPathToolTip">Change the SIT EFT Install Path.</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsButtonChangeTitle">Change</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathPlaceholder">SIT EFT Install Path...</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -380,6 +380,7 @@
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorTitle">Ошибка выбора местоположения</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorDescription">Вы выбрали ту же папку, что и установка BSG EFT, выберите другое местоположение для установки SIT</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionSPTErrorDescription">Вы выбрали ту же папку, что и существующая установка SPT. Выберите другое местоположение для установки SIT.</system:String>
+	<system:String x:Key="ConfigureSitViewModelLocationSelectionOneDriveErrorDescription">We think you've selected your 'OneDrive' folder which is known to cause issue, please choose a different location to install SIT to</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorOk">Ок</system:String>
 
 	<!-- Install - Install View -->

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -363,7 +363,8 @@
 
 	<!-- Install - Configure Sit View -->
 	<system:String x:Key="ConfigureSitViewLoadingVersionSelectionText">Определение доступных версий SIT, пожалуйста, подождите...</system:String>
-	<system:String x:Key="ConfigureSitViewVersionSelectionErrorMessage">Не удалось определить доступные версии SIT...</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionNoneAvailableErrorMessage">No version of SIT available for your current version of EFT. Please make sure your EFT is up to date</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionGenericErrorMessage">Не удалось определить доступные версии SIT...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTChangeInstallPathToolTip">Изменить путь установки SIT EFT.</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathPlaceholder">Путь установки SIT EFT...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathTitle">Путь установки SIT EFT:</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -364,7 +364,8 @@
 
 	<!-- Install - Configure Sit View -->
 	<system:String x:Key="ConfigureSitViewLoadingVersionSelectionText">Визначення доступних версій SIT, будь ласка, зачекайте...</system:String>
-	<system:String x:Key="ConfigureSitViewVersionSelectionErrorMessage">Не вдалося визначити доступні версії SIT...</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionNoneAvailableErrorMessage">No version of SIT available for your current version of EFT. Please make sure your EFT is up to date</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionGenericErrorMessage">Не вдалося визначити доступні версії SIT...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTChangeInstallPathToolTip">Змінити шлях встановлення SIT EFT.</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathPlaceholder">Шлях встановлення SIT EFT...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathTitle">Шлях встановлення SIT EFT:</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -381,6 +381,7 @@
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorTitle">Помилка вибору місця розташування</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorDescription">Ви вибрали ту саму теку, що і встановлення BSG EFT, оберіть інше місце для встановлення SIT</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionSPTErrorDescription">Ви обрали ту саму теку, що і існуюча установка SPT. Виберіть інше місце для установки SIT.</system:String>
+	<system:String x:Key="ConfigureSitViewModelLocationSelectionOneDriveErrorDescription">We think you've selected your 'OneDrive' folder which is known to cause issue, please choose a different location to install SIT to</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorOk">Oк</system:String>
 
 	<!-- Install - Install View -->

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -364,7 +364,8 @@
 
 	<!-- Install - Configure Sit View -->
 	<system:String x:Key="ConfigureSitViewLoadingVersionSelectionText">正在确定可用的 SIT 版本，请稍候...</system:String>
-	<system:String x:Key="ConfigureSitViewVersionSelectionErrorMessage">无法确定可用的 SIT 版本...</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionNoneAvailableErrorMessage">No version of SIT available for your current version of EFT. Please make sure your EFT is up to date</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionGenericErrorMessage">无法确定可用的 SIT 版本...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTChangeInstallPathToolTip">更改 SIT EFT 安装路径。</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathPlaceholder">SIT EFT 安装路径...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathTitle">SIT EFT 安装路径:</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -381,6 +381,7 @@
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorTitle">位置选择错误</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorDescription">您选择了与 BSG EFT 安装相同的目录，请选择另一个位置以安装 SIT</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionSPTErrorDescription">您选择了与现有的 SPT 安装相同的文件夹，请选择其他位置来安装 SIT。</system:String>
+	<system:String x:Key="ConfigureSitViewModelLocationSelectionOneDriveErrorDescription">We think you've selected your 'OneDrive' folder which is known to cause issue, please choose a different location to install SIT to</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorOk">好的</system:String>
 
 	<!-- Install - Install View -->

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -380,6 +380,7 @@
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorTitle">位置選擇錯誤</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorDescription">您選擇了與 BSG EFT 安裝相同的目錄，請選擇另一個位置以安裝 SIT</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionSPTErrorDescription">您選擇了與現有的 SPT 安裝相同的文件夾，請選擇其他位置進行 SIT 安裝。</system:String>
+	<system:String x:Key="ConfigureSitViewModelLocationSelectionOneDriveErrorDescription">We think you've selected your 'OneDrive' folder which is known to cause issue, please choose a different location to install SIT to</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorOk">好的</system:String>
 
 	<!-- Install - Install View -->

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -363,7 +363,8 @@
 
 	<!-- Install - Configure Sit View -->
 	<system:String x:Key="ConfigureSitViewLoadingVersionSelectionText">正在確定可用的 SIT 版本，請稍候...</system:String>
-	<system:String x:Key="ConfigureSitViewVersionSelectionErrorMessage">無法確定可用的 SIT 服务器版本...</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionNoneAvailableErrorMessage">No version of SIT available for your current version of EFT. Please make sure your EFT is up to date</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionGenericErrorMessage">無法確定可用的 SIT 服务器版本...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTChangeInstallPathToolTip">更改 EFT 的安裝路徑。</system:String>
 	<system:String x:Key="ConfigureSitViewEFTSettingsButtonChangeTitle">更改</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathPlaceholder">SIT EFT 安裝路徑...</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -364,7 +364,8 @@
 
 	<!-- Install - Configure Sit View -->
 	<system:String x:Key="ConfigureSitViewLoadingVersionSelectionText">正在確定可用的 SIT 版本，請稍候...</system:String>
-	<system:String x:Key="ConfigureSitViewVersionSelectionErrorMessage">無法確定可用的 SIT 版本...</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionNoneAvailableErrorMessage">No version of SIT available for your current version of EFT. Please make sure your EFT is up to date</system:String>
+	<system:String x:Key="ConfigureSitViewVersionSelectionGenericErrorMessage">無法確定可用的 SIT 版本...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTChangeInstallPathToolTip">更改 SIT EFT 安裝路徑。</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathPlaceholder">SIT EFT 安裝路徑...</system:String>
 	<system:String x:Key="ConfigureSitViewEFTInstallPathTitle">SIT EFT 安裝路徑:</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -381,6 +381,7 @@
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorTitle">位置選擇錯誤</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorDescription">您選擇了與 BSG EFT 安裝相同的目錄，請選擇另一個位置以安裝 SIT</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionSPTErrorDescription">您選擇了與現有的 SPT 安裝相同的資料夾，請選擇其他位置進行 SIT 安裝。</system:String>
+	<system:String x:Key="ConfigureSitViewModelLocationSelectionOneDriveErrorDescription">We think you've selected your 'OneDrive' folder which is known to cause issue, please choose a different location to install SIT to</system:String>
 	<system:String x:Key="ConfigureSitViewModelLocationSelectionErrorOk">好的</system:String>
 
 	<!-- Install - Install View -->

--- a/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
@@ -52,6 +52,12 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
     [ObservableProperty]
     private bool _hasRecommendedModsAvailable = false;
 
+    [ObservableProperty]
+    private bool _showNoAvailableSitVersionSelectionError = false;
+
+    [ObservableProperty]
+    private bool _showGenericSitVersionSelectionError = false;
+
     public ObservableCollection<SitInstallVersion> AvailableVersions { get; } = [];
     public ObservableCollection<KeyValuePair<string, string>> AvailableMirrors { get; } = [];
     public ObservableCollection<ModInfo> Mods { get; } = [];
@@ -176,11 +182,13 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
             }
             else
             {
+                ShowNoAvailableSitVersionSelectionError = true;
                 _logger.LogWarning("Available SIT version count {availableVersions} and 0 marked as available to use so will display error message", availableVersions.Count);
             }
         }
         catch (Exception ex)
         {
+            ShowGenericSitVersionSelectionError = true;
             _logger.LogError(ex, "Issue trying to determine versions available to install for SIT");
         }
 
@@ -322,6 +330,10 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
                 return;
             }
         }
+
+        // Reset the error messages
+        ShowNoAvailableSitVersionSelectionError = false;
+        ShowGenericSitVersionSelectionError = false;
 
         OverridenBsgInstallPath = CurrentInstallProcessState.BsgInstallPath != CurrentInstallProcessState.EftInstallPath;
         await Task.WhenAll(LoadAvailableModsList(), FetchVersionAndMirrorMatrix());

--- a/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
@@ -106,6 +106,18 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
                 usingInvalidLocatiion = true;
             }
 
+            if (HasSelectedOneDriveInstallPath(CurrentInstallProcessState.EftInstallPath))
+            {
+                // Using OneDrive install location which is known to cause issues so we don't want this as a location for the SIT install.
+                await new ContentDialog()
+                {
+                    Title = _localizationService.TranslateSource("ConfigureSitViewModelLocationSelectionErrorTitle"),
+                    Content = _localizationService.TranslateSource("ConfigureSitViewModelLocationSelectionOneDriveErrorDescription"),
+                    PrimaryButtonText = _localizationService.TranslateSource("ConfigureSitViewModelLocationSelectionErrorOk")
+                }.ShowAsync();
+                usingInvalidLocatiion = true;
+            }
+
             if (!usingInvalidLocatiion)
             {
                 CurrentInstallProcessState.EftInstallPath = directorySelected.Path.LocalPath;
@@ -180,10 +192,23 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
     }
 
     /// <summary>
+    /// Check if the currently selected EFT install directory has indicators of a OneDrive install lication and if so return true, otherwise return false
+    /// </summary>
+    /// <returns>True if this is a OneDrive directory otherwise false</returns>
+    private static bool HasSelectedOneDriveInstallPath(string requestedDirectory)
+    {
+        if (requestedDirectory.Contains("OneDrive"))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Check if the currently selected EFT diretory has indicators of an SPT install and if so return true, otherwise return false
     /// </summary>
     /// <returns>True if this is an SPT install directory otherwise false</returns>
-    private bool HasSelectedSPTInstallPath(string requestedDirectory)
+    private static bool HasSelectedSPTInstallPath(string requestedDirectory)
     {
         string sptLauncherPath = Path.Combine(requestedDirectory, "Aki.Launcher.exe");
         string sptServerPath = Path.Combine(requestedDirectory, "Aki.Server.exe");
@@ -211,15 +236,6 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
     {
         IsConfigurationValid = true;
 
-        if (CurrentInstallProcessState.UsingBsgInstallPath)
-        {
-            if (CurrentInstallProcessState.BsgInstallPath == CurrentInstallProcessState.EftInstallPath)
-            {
-                IsConfigurationValid = false;
-                return;
-            }
-        }
-
         if (string.IsNullOrEmpty(CurrentInstallProcessState.EftInstallPath))
         {
             IsConfigurationValid = false;
@@ -244,7 +260,17 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
             return;
         }
 
+        if (CurrentInstallProcessState.BsgInstallPath == CurrentInstallProcessState.EftInstallPath)
+        {
+            IsConfigurationValid = false;
+            return;
+        }
         if (HasSelectedSPTInstallPath(CurrentInstallProcessState.EftInstallPath))
+        {
+            IsConfigurationValid = false;
+            return;
+        }
+        if (HasSelectedOneDriveInstallPath(CurrentInstallProcessState.EftInstallPath))
         {
             IsConfigurationValid = false;
             return;

--- a/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
+++ b/SIT.Manager/ViewModels/Installation/ConfigureSitViewModel.cs
@@ -194,11 +194,7 @@ public partial class ConfigureSitViewModel : InstallationViewModelBase
     /// <returns>True if this is a OneDrive directory otherwise false</returns>
     private static bool HasSelectedOneDriveInstallPath(string requestedDirectory)
     {
-        if (requestedDirectory.Contains("OneDrive"))
-        {
-            return true;
-        }
-        return false;
+        return requestedDirectory.Contains("OneDrive");
     }
 
     /// <summary>

--- a/SIT.Manager/ViewModels/Play/ServerSummaryViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/ServerSummaryViewModel.cs
@@ -153,9 +153,10 @@ public partial class ServerSummaryViewModel : ObservableRecipient
 
     private async void DispatcherTimer_Tick(object? sender, EventArgs e)
     {
+        _dispatcherTimer.Stop();
+
         try
         {
-            _dispatcherTimer.Stop();
             Ping = await _serverService.GetPingAsync(_server);
             _logger.LogDebug("{Name}'s ping is {Ping}ms", Name, Ping);
         }
@@ -164,7 +165,8 @@ public partial class ServerSummaryViewModel : ObservableRecipient
             Ping = -1;
             _logger.LogWarning(ex, "Couldn't evaluate ping from server {Name}", Name);
         }
-        finally
+
+        if (IsActive)
         {
             _dispatcherTimer.Start();
         }
@@ -172,6 +174,8 @@ public partial class ServerSummaryViewModel : ObservableRecipient
 
     private async Task RefreshServerData()
     {
+        _dispatcherTimer.Stop();
+
         try
         {
             _server = await _serverService.GetAkiServerAsync(_server.Address);

--- a/SIT.Manager/Views/Installation/ConfigureSitView.axaml
+++ b/SIT.Manager/Views/Installation/ConfigureSitView.axaml
@@ -20,17 +20,28 @@
 				<TextBlock Text="{DynamicResource ConfigureViewVersionSelectionGroupTitle}" Classes="FrameHeading"/>
 				<Border Classes="StandardFrame">
 					<StackPanel>
-						<TextBlock Text="{DynamicResource ConfigureSitViewVersionSelectionErrorMessage}"
-								   Classes="ErrorMessage"
-								   VerticalAlignment="Center"
-								   Margin="0,0,8,0">
-							<TextBlock.IsVisible>
+						<StackPanel>
+							<StackPanel.IsVisible>
 								<MultiBinding Converter="{x:Static BoolConverters.And}">
 									<Binding Path="!IsVersionSelectionLoading"/>
 									<Binding Path="!HasVersionsAvailable"/>
 								</MultiBinding>
-							</TextBlock.IsVisible>
-						</TextBlock>
+							</StackPanel.IsVisible>
+
+							<TextBlock Classes="ErrorMessage"
+									   VerticalAlignment="Center"
+									   TextWrapping="Wrap"
+									   Margin="0,0,8,0"
+									   IsVisible="{Binding ShowNoAvailableSitVersionSelectionError}"
+									   Text="{DynamicResource ConfigureSitViewVersionSelectionNoneAvailableErrorMessage}"/>
+
+							<TextBlock Classes="ErrorMessage"
+									   VerticalAlignment="Center"
+									   TextWrapping="Wrap"
+									   Margin="0,0,8,0"
+									   IsVisible="{Binding ShowGenericSitVersionSelectionError}"
+									   Text="{DynamicResource ConfigureSitViewVersionSelectionGenericErrorMessage}"/>
+						</StackPanel>
 
 						<Grid ColumnDefinitions="auto, *">
 							<Grid.IsVisible>

--- a/SIT.Manager/Views/Settings/EftView.axaml
+++ b/SIT.Manager/Views/Settings/EftView.axaml
@@ -46,7 +46,7 @@
 					   TextTrimming="CharacterEllipsis"
 					   TextWrapping="WrapWithOverflow"
 					   Text="{DynamicResource EftViewModelSitEftInstallPathMissing}"
-					   IsVisible="{Binding SitEftInstallPath}, Converter={x:Static StringConverters.IsNullOrEmpty}}"/>
+					   IsVisible="{Binding SitEftInstallPath, Converter={x:Static StringConverters.IsNullOrEmpty}}"/>
 			<Button Grid.Column="2"
 					Grid.Row="1"
 					VerticalAlignment="Center"


### PR DESCRIPTION
A few fixes and tweaks to hopefully improve things:

1. Reduce the excessive number of pings to bookmarked servers as it would be pinging the server even when the view wasn't activated
2. Add a first super basic check for installing to OneDrive should resolve #245
3. Fix the manager getting confused and showing multiple text over each other when looking at EFT settings
4. Show a more helpful error message when unable to determine a SIT version to install.