### PR TITLE
Be consistent with in memory and on disk caches

### DIFF
--- a/SIT.Manager/Services/Caching/CachingProviderBase.cs
+++ b/SIT.Manager/Services/Caching/CachingProviderBase.cs
@@ -48,7 +48,7 @@ internal abstract class CachingProviderBase : ICachingProvider
         string keyDataPath = Path.Combine(_cachePath.FullName, restoreFileName);
         if (_cacheMap.IsEmpty)
         {
-            if(File.Exists(keyDataPath))
+            if (File.Exists(keyDataPath))
                 File.Delete(keyDataPath);
             return;
         }
@@ -59,13 +59,13 @@ internal abstract class CachingProviderBase : ICachingProvider
         if (state == null)
             return;
 
-        ConcurrentDictionary<string, CacheEntry> cache = (ConcurrentDictionary<string, CacheEntry>)state;
-        foreach(CacheEntry entry in cache.Values)
+        ConcurrentDictionary<string, CacheEntry> cache = (ConcurrentDictionary<string, CacheEntry>) state;
+        foreach (CacheEntry entry in cache.Values)
         {
             if (entry.ExpiryDate >= DateTime.UtcNow)
                 continue;
 
-            if(Remove(entry.Key))
+            if (Remove(entry.Key))
                 Evicted?.Invoke(this, new EvictedEventArgs(entry.Key));
         }
 
@@ -153,7 +153,7 @@ internal abstract class CachingProviderBase : ICachingProvider
     public virtual bool TryGet<T>(string key, out CacheValue<T> cacheValue)
     {
         cacheValue = Get<T>(key);
-        return cacheValue != CacheValue<T>.Null;
+        return cacheValue != CacheValue<T>.NoValue;
     }
 
     protected virtual void OnEvictedTenant(EvictedEventArgs e)

--- a/SIT.Manager/Services/Caching/InMemoryCachingProvider.cs
+++ b/SIT.Manager/Services/Caching/InMemoryCachingProvider.cs
@@ -1,20 +1,15 @@
-﻿using Avalonia.Controls.ApplicationLifetimes;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text.Json;
-using System.Threading;
 
 namespace SIT.Manager.Services.Caching;
 
 internal class InMemoryCachingProvider(string cachePath, ILogger<InMemoryCachingProvider> logger) : CachingProviderBase(cachePath)
 {
     private const string RESTORE_FILE_NAME = "memoryCache.dat";
+
+    private readonly ILogger<InMemoryCachingProvider> _logger = logger;
+
     protected override string RestoreFileName => RESTORE_FILE_NAME;
-    private ILogger<InMemoryCachingProvider> _logger = logger;
 
     public override CacheValue<T> Get<T>(string key)
     {
@@ -25,7 +20,7 @@ internal class InMemoryCachingProvider(string cachePath, ILogger<InMemoryCaching
 
         if (cacheEntry.ExpiryDate < DateTime.UtcNow)
         {
-            if(Remove(cacheEntry.Key))
+            if (Remove(cacheEntry.Key))
                 OnEvictedTenant(new EvictedEventArgs(cacheEntry.Key));
             return CacheValue<T>.NoValue;
         }
@@ -51,7 +46,7 @@ internal class InMemoryCachingProvider(string cachePath, ILogger<InMemoryCaching
         CacheEntry cacheEntry = new(key, value, expiryDate);
         if (expiryDate < DateTime.UtcNow)
         {
-            if(Remove(cacheEntry.Key))
+            if (Remove(cacheEntry.Key))
                 OnEvictedTenant(new EvictedEventArgs(cacheEntry.Key));
             return false;
         }

--- a/SIT.Manager/Services/Caching/OnDiskCachingProvider.cs
+++ b/SIT.Manager/Services/Caching/OnDiskCachingProvider.cs
@@ -29,7 +29,7 @@ internal class OnDiskCachingProvider(string cachePath, ILogger<OnDiskCachingProv
                 if (string.IsNullOrEmpty(file.Extension) && !validFileNames.Contains(file.Name))
                     file.Delete();
             }
-            base.CleanCache();   
+            base.CleanCache();
         }
     }
 
@@ -64,7 +64,7 @@ internal class OnDiskCachingProvider(string cachePath, ILogger<OnDiskCachingProv
                 else
                 {
                     string serializedData = JsonSerializer.Serialize(value);
-                    buffer = Encoding.UTF8.GetBytes(serializedData);   
+                    buffer = Encoding.UTF8.GetBytes(serializedData);
                 }
 
                 fs.Write(buffer);
@@ -88,7 +88,7 @@ internal class OnDiskCachingProvider(string cachePath, ILogger<OnDiskCachingProv
             string cacheFilePath = cacheEntry.GetValue<string>();
             if (File.Exists(cacheFilePath))
                 File.Delete(cacheFilePath);
-            if(Remove(key))
+            if (Remove(key))
                 OnEvictedTenant(new EvictedEventArgs(key));
             return CacheValue<T>.NoValue;
         }
@@ -100,7 +100,7 @@ internal class OnDiskCachingProvider(string cachePath, ILogger<OnDiskCachingProv
             {
                 Remove(cacheEntry.Key);
                 OnEvictedTenant(new EvictedEventArgs(cacheEntry.Key));
-                return CacheValue<T>.Null;
+                return CacheValue<T>.NoValue;
             }
 
             Type tType = typeof(T);
@@ -112,7 +112,7 @@ internal class OnDiskCachingProvider(string cachePath, ILogger<OnDiskCachingProv
             _ = fs.Read(fileBytes, 0, fileBytes.Length);
 
             if (tType == typeof(byte[]))
-                return new CacheValue<T>((T)(object)fileBytes, true);
+                return new CacheValue<T>((T) (object) fileBytes, true);
 
             return new CacheValue<T>(JsonSerializer.Deserialize<T>(fileBytes), true);
         }


### PR DESCRIPTION
Switch TryGet<T> to compare with ```CacheValue<T>.NoValue``` as this is what the Get<T> functions implemented by InMemoryCachingProvider & OnDiskCachingProvider mostly returned 

Then change the one case where OnDiskCachingProvider returned ```CacheValue<T>.Null```