### PR TITLE
Make the buttons on the configure installs pages more unified

### DIFF
--- a/SIT.Manager/Theme/Styles/Button.axaml
+++ b/SIT.Manager/Theme/Styles/Button.axaml
@@ -1,0 +1,45 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Design.PreviewWith>
+        <Border Padding="20">
+			<StackPanel>
+				<Button Classes="IsolatedButton">
+					<StackPanel Orientation="Horizontal">
+						<TextBlock Text="{DynamicResource ConfigureViewBackButtonTitle}"
+								   TextTrimming="CharacterEllipsis"/>
+					</StackPanel>
+				</Button>
+			</StackPanel>
+		</Border>
+    </Design.PreviewWith>
+
+	<Style Selector="Button:pointerover">
+		<Setter Property="Cursor" Value="Hand"/>
+	</Style>
+
+	<Style Selector="Button:pressed">
+		<Setter Property="Cursor" Value="Hand"/>
+	</Style>
+
+    <!-- Add Styles Here -->
+	<Style Selector="Button.IsolatedButton">
+		<Setter Property="CornerRadius" Value="4"/>
+		<Setter Property="Background" Value="{DynamicResource AppPrimary}"/>
+		<Setter Property="Height" Value="48"/>
+		<Setter Property="HorizontalAlignment" Value="Stretch"/>
+		<Setter Property="HorizontalContentAlignment" Value="Center"/>
+		<Setter Property="Margin" Value="4"/>
+	</Style>
+
+	<Style Selector="Button.IsolatedButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="CornerRadius" Value="4"/>
+	</Style>
+	
+	<Style Selector="Button.IsolatedButton:pressed">
+		<Setter Property="RenderTransform" Value="scale(0.98)" />
+	</Style>
+
+	<Style Selector="Button.IsolatedButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
+		<Setter Property="CornerRadius" Value="4"/>
+	</Style>
+</Styles>

--- a/SIT.Manager/Theme/Theme.axaml
+++ b/SIT.Manager/Theme/Theme.axaml
@@ -14,6 +14,7 @@
 
 	<!-- Styles -->
 	<StyleInclude Source="avares://SIT.Manager.ASM/Theme/Styles/Border.axaml"/>
+	<StyleInclude Source="avares://SIT.Manager.ASM/Theme/Styles/Button.axaml"/>
 	<StyleInclude Source="avares://SIT.Manager.ASM/Theme/Styles/SelectableTextBlock.axaml"/>
 	<StyleInclude Source="avares://SIT.Manager.ASM/Theme/Styles/TextBlock.axaml"/>
 </Styles>

--- a/SIT.Manager/Views/Installation/ConfigureServerView.axaml
+++ b/SIT.Manager/Views/Installation/ConfigureServerView.axaml
@@ -97,28 +97,23 @@
 			  ColumnDefinitions="*, *"
 			  Margin="4,4,4,8">
 			<Button Grid.Column="0"
-					Background="Black"
-					Height="50"
-					Margin="0,0,5,0"
-					HorizontalAlignment="Stretch"
-					HorizontalContentAlignment="Center"
+					Classes="IsolatedButton"
 					Command="{Binding BackCommand}">
 				<StackPanel Orientation="Horizontal">
 					<ui:SymbolIcon Symbol="Back"/>
-					<TextBlock Text="{DynamicResource ConfigureViewBackButtonTitle}" TextTrimming="CharacterEllipsis"/>
+					<TextBlock Text="{DynamicResource ConfigureViewBackButtonTitle}" 
+							   TextTrimming="CharacterEllipsis"/>
 				</StackPanel>
 			</Button>
 
 			<Button Grid.Column="1"
-					Background="Black"
-					Height="50"
-					HorizontalAlignment="Stretch"
-					HorizontalContentAlignment="Center"
+					Classes="IsolatedButton"
 					IsEnabled="{Binding IsConfigurationValid}"
 					Command="{Binding StartCommand}">
 				<StackPanel Orientation="Horizontal">
 					<ui:SymbolIcon Symbol="PlayFilled"/>
-					<TextBlock Text="{DynamicResource ConfigureViewStartInstallButtonTitle}" TextTrimming="CharacterEllipsis"/>
+					<TextBlock Text="{DynamicResource ConfigureViewStartInstallButtonTitle}" 
+							   TextTrimming="CharacterEllipsis"/>
 				</StackPanel>
 			</Button>
 		</Grid>

--- a/SIT.Manager/Views/Installation/ConfigureSitView.axaml
+++ b/SIT.Manager/Views/Installation/ConfigureSitView.axaml
@@ -171,28 +171,23 @@
 			<Grid ColumnDefinitions="*, *"
 				  Margin="4,8">
 				<Button Grid.Column="0"
-						Background="Black"
-						Height="50"
-						Margin="0,0,5,0"
-						HorizontalAlignment="Stretch"
-						HorizontalContentAlignment="Center"
+						Classes="IsolatedButton"
 						Command="{Binding BackCommand}">
 					<StackPanel Orientation="Horizontal">
 						<ui:SymbolIcon Symbol="Back"/>
-						<TextBlock Text="{DynamicResource ConfigureViewBackButtonTitle}"/>
+						<TextBlock Text="{DynamicResource ConfigureViewBackButtonTitle}" 
+								   TextTrimming="CharacterEllipsis"/>
 					</StackPanel>
 				</Button>
 
 				<Button Grid.Column="1"
-						Background="Black"
-						Height="50"
-						HorizontalAlignment="Stretch"
-						HorizontalContentAlignment="Center"
+						Classes="IsolatedButton"
 						IsEnabled="{Binding IsConfigurationValid}"
 						Command="{Binding StartCommand}">
 					<StackPanel Orientation="Horizontal">
 						<ui:SymbolIcon Symbol="PlayFilled"/>
-						<TextBlock Text="{DynamicResource ConfigureViewStartInstallButtonTitle}"/>
+						<TextBlock Text="{DynamicResource ConfigureViewStartInstallButtonTitle}" 
+								   TextTrimming="CharacterEllipsis"/>
 					</StackPanel>
 				</Button>
 			</Grid>


### PR DESCRIPTION
Essentially apply the same theming ideas to these buttons as there is almost everywhere else. It doesn't seem to work brilliantly but I think that's more down to some things in FluentAvalonia getting in the way, can look into those later.