### PR TITLE
Make OnDiskCachingProvider Filestream safe.

### DIFF
--- a/SIT.Manager/Services/Caching/OnDiskCachingProvider.cs
+++ b/SIT.Manager/Services/Caching/OnDiskCachingProvider.cs
@@ -104,17 +104,19 @@ internal class OnDiskCachingProvider(string cachePath, ILogger<OnDiskCachingProv
             }
 
             Type tType = typeof(T);
-            FileStream fs = File.OpenRead(filePath);
-            if (tType == typeof(Stream))
-                return new CacheValue<T>((T) (object) fs, true);
+            using (FileStream fs = File.OpenRead(filePath))
+            {
+                if (tType == typeof(Stream))
+                    return new CacheValue<T>((T) (object) fs, true);
 
-            byte[] fileBytes = new byte[fs.Length - fs.Position];
-            _ = fs.Read(fileBytes, 0, fileBytes.Length);
+                byte[] fileBytes = new byte[fs.Length - fs.Position];
+                _ = fs.Read(fileBytes, 0, fileBytes.Length);
 
-            if (tType == typeof(byte[]))
-                return new CacheValue<T>((T) (object) fileBytes, true);
+                if (tType == typeof(byte[]))
+                    return new CacheValue<T>((T) (object) fileBytes, true);
 
-            return new CacheValue<T>(JsonSerializer.Deserialize<T>(fileBytes), true);
+                return new CacheValue<T>(JsonSerializer.Deserialize<T>(fileBytes), true);
+            }
         }
         catch (Exception ex)
         {

--- a/SIT.Manager/ViewModels/PlayPageViewModel.cs
+++ b/SIT.Manager/ViewModels/PlayPageViewModel.cs
@@ -31,10 +31,11 @@ public partial class PlayPageViewModel : ObservableRecipient,
     {
         _cachingService = cachingService;
 
-        if (_cachingService.OnDisk.TryGet(SELECTED_TAB_INDEX_CACHE_KEY, out CacheValue<int> indexValue))
+        CacheValue<int> indexValue = _cachingService.OnDisk.GetOrCompute(SELECTED_TAB_INDEX_CACHE_KEY, (key) =>
         {
-            SelectedTabIndex = indexValue.Value;
-        }
+            return SelectedTabIndex;
+        });
+        SelectedTabIndex = indexValue.Value;
 
         PlayControl = new ServerSelectionView();
     }


### PR DESCRIPTION
Make the Filestream in the OnDiskCachingProvider use a using statement so it clears itself from being used by the time we need to use the file again.