### PR TITLE
Added new setting to allow the launcher to Minimize on game launch - …

### DIFF
--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -80,9 +80,11 @@
 
 	<!-- Settings Page -->
 	<system:String x:Key="SettingsLauncherSettingsTitle">Launcher</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchTitle">Minimize Launcher After Game Launch</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchToolTip">Minimizes the launcher automatically after opening the game.</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchTitle">Close Launcher After Game Launch</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchToolTip">Closes the launcher automatically after opening the game.</system:String>
-	<system:String x:Key="SettingsLookForUpdatesTitle">Look For Updates</system:String>
+    <system:String x:Key="SettingsLookForUpdatesTitle">Look For Updates</system:String>
 	<system:String x:Key="SettingsLookForUpdatesTitleToolTip">Automatically look for updates when opening the launcher.</system:String>
 	<system:String x:Key="SettingsHideIpAddressTitle">Hide Ip Address</system:String>
 	<system:String x:Key="SettingsHideIpAddressToolTip">Hides the Ip Address with the star symbols in Ip Address Box.</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -80,6 +80,8 @@
 
 	<!-- Settings Page -->
 	<system:String x:Key="SettingsLauncherSettingsTitle">Настройки Лаунчера</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchTitle">Минимизация лаунчера после запуска игры</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchToolTip">Автоматически сворачивает пусковую установку после открытия игры.</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchTitle">Закрыть лаунчер после запуска игры</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchToolTip">Автоматически закрывает лаунчер после открытия игры.</system:String>
 	<system:String x:Key="SettingsLookForUpdatesTitle">Проверять Обновления</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -84,6 +84,8 @@
 
 	<!-- Settings Page -->
 	<system:String x:Key="SettingsLauncherSettingsTitle">Налаштування Лаунчера</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchTitle">Згортає лаунчер автоматично після відкриття гри.</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchToolTip">Згортає лаунчер автоматично після відкриття гри.</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchTitle">Закрити лаунчер після запуску гри</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchToolTip">Автоматично закриває лаунчер після відкриття гри.</system:String>
 	<system:String x:Key="SettingsLookForUpdatesTitle">Перевіряти Оновлення</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -80,6 +80,8 @@
 	
 	<!-- Settings Page -->
 	<system:String x:Key="SettingsLauncherSettingsTitle">启动器设置</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchTitle">游戏启动后最小化启动器</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchToolTip">打开游戏后自动最小化启动器</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchTitle">游戏启动后关闭启动器</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchToolTip">打开游戏后自动关闭启动器</system:String>
 	<system:String x:Key="SettingsLookForUpdatesTitle">检查更新</system:String>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -80,6 +80,8 @@
 	
 	<!-- Settings Page -->
 	<system:String x:Key="SettingsLauncherSettingsTitle">啟動器設定</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchTitle">游戏启动后最小化启动器</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchToolTip">打开游戏后自动最小化启动器</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchTitle">遊戲啟動後關閉啟動器</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchToolTip">打開遊戲後自動關閉啟動器</system:String>
 	<system:String x:Key="SettingsLookForUpdatesTitle">檢查更新</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -80,6 +80,8 @@
 	
 	<!-- Settings Page -->
 	<system:String x:Key="SettingsLauncherSettingsTitle">啟動器設定</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchTitle">游戏启动后最小化启动器</system:String>
+    <system:String x:Key="SettingsMinimizeLauncherAfterGameLaunchToolTip">打开游戏后自动最小化启动器</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchTitle">遊戲啟動後關閉啟動器</system:String>
 	<system:String x:Key="SettingsCloseLauncherAfterGameLaunchToolTip">開啟遊戲後自動關閉啟動器</system:String>
 	<system:String x:Key="SettingsLookForUpdatesTitle">檢查更新</system:String>

--- a/SIT.Manager/Models/Config/ManagerConfig.cs
+++ b/SIT.Manager/Models/Config/ManagerConfig.cs
@@ -13,6 +13,8 @@ public partial class ManagerConfig : ObservableObject
     [ObservableProperty]
     private Color? _accentColor = Color.FromRgb(0x7f, 0x7f, 0x7f);
     [ObservableProperty]
+    public bool _minimizeAfterLaunch = false;
+    [ObservableProperty]
     public bool _closeAfterLaunch = false;
     [ObservableProperty]
     public string _currentLanguageSelected = CultureInfo.CurrentCulture.Name;

--- a/SIT.Manager/Services/ManagedProcesses/TarkovClientService.cs
+++ b/SIT.Manager/Services/ManagedProcesses/TarkovClientService.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.ApplicationLifetimes;
+﻿using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using FluentAvalonia.UI.Controls;
 using Microsoft.Extensions.Logging;
 using SIT.Manager.Exceptions;
@@ -55,6 +56,16 @@ public class TarkovClientService(IAkiServerRequestingService serverRequestingSer
         {
             // Handle the case where InstallPath is not found or empty.
             _barNotificationService.ShowError(_localizationService.TranslateSource("TarkovClientServiceCacheClearedErrorTitle"), _localizationService.TranslateSource("TarkovClientServiceCacheClearedErrorDescription"));
+        }
+    }
+
+    private static void MinimizeManager()
+    {
+        IApplicationLifetime? lifetime = App.Current.ApplicationLifetime;
+
+        if (lifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: not null } desktopLifetime)
+        {
+            desktopLifetime.MainWindow.WindowState = WindowState.Minimized;
         }
     }
 
@@ -182,6 +193,11 @@ public class TarkovClientService(IAkiServerRequestingService serverRequestingSer
                 Content = ex.Message
             }.ShowAsync();
             return false;
+        }
+
+        if (_configService.Config.MinimizeAfterLaunch)
+        {
+            MinimizeManager();
         }
 
         if (_configService.Config.CloseAfterLaunch)

--- a/SIT.Manager/Views/Settings/LauncherView.axaml
+++ b/SIT.Manager/Views/Settings/LauncherView.axaml
@@ -11,9 +11,12 @@
 	<StackPanel Margin="16,8">
 		<controls:Card Margin="0,8">
 			<StackPanel>
+                <CheckBox Content="{DynamicResource SettingsMinimizeLauncherAfterGameLaunchTitle}"
+                          ToolTip.Tip="{DynamicResource SettingsMinimizeLauncherAfterGameLaunchToolTip}"
+                          IsChecked="{Binding Config.MinimizeAfterLaunch, Mode=TwoWay}"/>
 				<CheckBox Content="{DynamicResource SettingsCloseLauncherAfterGameLaunchTitle}"
-						  ToolTip.Tip="{DynamicResource SettingsCloseLauncherAfterGameLaunchToolTip}"
-						  IsChecked="{Binding Config.CloseAfterLaunch, Mode=TwoWay}"/>
+                          ToolTip.Tip="{DynamicResource SettingsCloseLauncherAfterGameLaunchToolTip}"
+                          IsChecked="{Binding Config.CloseAfterLaunch, Mode=TwoWay}"/>
 				<CheckBox Content="{DynamicResource SettingsLookForUpdatesTitle}"
 						  ToolTip.Tip="{DynamicResource SettingsLookForUpdatesTitleToolTip}"
 						  IsChecked="{Binding Config.LookForUpdates, Mode=TwoWay}"/>


### PR DESCRIPTION
…tested in Desktop mode (should only effect Desktop mode - please correct me if I am wrong, never used Avalonia before).

Language resources updated with text for setting and tooltip - can only test en-US, other languages were done with online translating tools - however text looks very similar to the setting for Close on launch so presume it is ok.  Really needs to be checked by native language speakers.

Resulting launcher settings screen is as follows:

![image](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/f402b388-5cb8-441d-bdf8-0c03660e3a03)

As soon as the Play button is pressed (or successful login), launcher checks to see if the minimize setting is enabled, that we are in desktop mode, and that there is a MainWindow - if so WindowState is set to Minimized as the EFT executable is started..