### PR TITLE
Enable and Disable the Login and Play buttons on Character Summary view dependent on EFT's running state.

### DIFF
--- a/SIT.Manager/ViewModels/Play/CharacterSummaryViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/CharacterSummaryViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using FluentAvalonia.UI.Controls;
@@ -40,6 +41,9 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
 
     [ObservableProperty]
     private bool _requireLogin = true;
+
+    [ObservableProperty]
+    public bool _canLaunch = true;
 
     public IAsyncRelayCommand PlayCommand { get; }
 
@@ -86,6 +90,11 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
         Task.Run(SetSideImage);
 
         PlayCommand = new AsyncRelayCommand(Play);
+
+        // In an ideal world we would use OnActivated and OnDeactivated - which are implemented from IActivatableViewModel in the Avalonia.ReactiveUI package.
+        // However, this would also require changes in the CharacterSummaryView class - for not this implementation, while crude, does suffice.
+        // It may be worth implementing Avalonia.ReactiveUI.IActivatableViewModel at a later date for all pages as part of a larger refactor.
+        _tarkovClientService.RunningStateChanged += TarkovClient_RunningStateChanged;
     }
 
     private async Task SetSideImage()
@@ -160,5 +169,25 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
             };
             await errorDialog.ShowAsync();
         }
+    }
+
+    private void TarkovClient_RunningStateChanged(object? sender, RunningState runningState)
+    {
+        Dispatcher.UIThread.Invoke(() =>
+        {
+            switch (runningState)
+            {
+                case RunningState.Starting:
+                case RunningState.Running:
+                    CanLaunch = false;
+
+                    break;
+                case RunningState.NotRunning:
+                case RunningState.StoppedUnexpectedly:
+                    CanLaunch = true;
+
+                    break;
+            }
+        });
     }
 }

--- a/SIT.Manager/Views/Play/CharacterSummaryView.axaml
+++ b/SIT.Manager/Views/Play/CharacterSummaryView.axaml
@@ -53,8 +53,8 @@
 			</StackPanel>
 
 			<Button Grid.Column="2"
-					Command="{Binding PlayCommand}">
-				<Panel>
+					Command="{Binding PlayCommand}" IsEnabled="{Binding CanLaunch}">
+                <Panel>
 					<TextBlock IsVisible="{Binding !RequireLogin}"
 							   Text="{DynamicResource CharacterSummaryViewPlayButtonText}"/>
 					<TextBlock IsVisible="{Binding RequireLogin}" 


### PR DESCRIPTION
Updated the CharacterSummaryViewModel to expose an additional property _canLaunch (with an Observable generated instance) which is set to either true or false (defaults to true) depending on the state of _tarkovClientService.RunningStateChanged.

An event handler is attached to listen for RunningStateChanged events, if the state is either Starting or Running _canLaunch is set to false, the other states (NotRunning and StoppedUnexpectedly) set this to true.

The CharacterSummaryView.axaml's command button (Login or Play) has the property IsEnabled bound to this new property - in doing this all buttons are enabled or disabled when EFT is started/stopped. This property is changed on the UI thread with the use of Dispatcher.UIThread.Invoke().

The upshot of this change is that the UI now behaves as such:

Not logged in, Tarkov not running, all buttons enabled:
![Unsaved profile - Tarkov not launched](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/f3ae56cd-f88d-456a-b264-d6ddf3718d04)

Login dialog disables the login button for the selected profile (as expected for a button with a bound command):
![Unsaved profile - Login Dialog](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/ffb25fba-eb52-4203-a028-2c7620382357)

Successful login, Tarkov now running (or starting up), all buttons are disabled:
![Unsaved profile - Tarkov running](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/3c3b6c64-2f66-47e6-a76a-43053469c62a)

Exited from Tarkov, all buttons are enabled.
![Unsaved profile - Tarkov exited](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/2f2fad3e-e227-4ef4-b972-bdea67e33c3b)

Saved profiles work in much the same way - but without the login dialog of course.

Saved profile (remember me ticked during login), Tarkov not running all buttons available.
![Saved profile - Tarkov not launched](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/2886bc18-25a4-479d-9a57-09e737c2d756)

Saved profile (remember me ticked during login), Tarkov running all buttons disabled.
![Saved profile - Tarkov launched](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/9ef4bb64-6ef8-4995-b5d9-87fca7f29ef6)

Saved profile (remember me ticked during login), Tarkov exited all buttons available again.
![Saved profile - Tarkov exited](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/8b30ba6a-4f83-4a3c-8a1e-53977e178571)

> [!NOTE]
> Have added comments in the CharacterSummaryViewModel constructor regarding future implementation of IActivatableViewModel from Avalonia.ReactiveUI - however it would require changes to the code behind the axaml. It *may* be worth looking into this as part of a larger refactor at a later date.