### PR TITLE
Added a logout button so that a "saved profile" can be forgotten.

### DIFF
--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -428,6 +428,7 @@
 	<!-- CharacterSummaryView -->
 	<system:String x:Key="CharacterSummaryViewPlayButtonText">Play</system:String>
 	<system:String x:Key="CharacterSummaryViewLoginButtonText">Login</system:String>
+	<system:String x:Key="CharacterSummaryViewLogoutButtonText">Logout</system:String>
 
 	<!-- CreateServerDialogView -->
 	<system:String x:Key="CreateServerDialogViewAddTitle">Add Server</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -429,6 +429,7 @@
 	<!-- CharacterSummaryView -->
 	<system:String x:Key="CharacterSummaryViewPlayButtonText">Играть</system:String>
 	<system:String x:Key="CharacterSummaryViewLoginButtonText">Войти</system:String>
+    <system:String x:Key="CharacterSummaryViewLogoutButtonText">Выход</system:String>
 
 	<!-- CreateServerDialogView -->
 	<system:String x:Key="CreateServerDialogViewAddTitle">Добавить сервер</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -430,6 +430,7 @@
 	<!-- CharacterSummaryView -->
 	<system:String x:Key="CharacterSummaryViewPlayButtonText">Грати</system:String>
 	<system:String x:Key="CharacterSummaryViewLoginButtonText">Ввійти</system:String>
+    <system:String x:Key="CharacterSummaryViewLogoutButtonText">Вихід</system:String>
 
 	<!-- CreateServerDialogView -->
 	<system:String x:Key="CreateServerDialogViewAddTitle">Додати сервер</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -430,6 +430,7 @@
 	<!-- CharacterSummaryView -->
 	<system:String x:Key="CharacterSummaryViewPlayButtonText">玩</system:String>
 	<system:String x:Key="CharacterSummaryViewLoginButtonText">登录</system:String>
+    <system:String x:Key="CharacterSummaryViewLogoutButtonText">注销</system:String>
 
 	<!-- CreateServerDialogView -->
 	<system:String x:Key="CreateServerDialogViewAddTitle">添加服务器</system:String>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -429,6 +429,7 @@
 	<!-- CharacterSummaryView -->
 	<system:String x:Key="CharacterSummaryViewPlayButtonText">玩</system:String>
 	<system:String x:Key="CharacterSummaryViewLoginButtonText">登錄</system:String>
+    <system:String x:Key="CharacterSummaryViewLogoutButtonText">注销</system:String>
 
 	<!-- CreateServerDialogView -->
 	<system:String x:Key="CreateServerDialogViewAddTitle">添加伺服器</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -430,6 +430,7 @@
 	<!-- CharacterSummaryView -->
 	<system:String x:Key="CharacterSummaryViewPlayButtonText">玩</system:String>
 	<system:String x:Key="CharacterSummaryViewLoginButtonText">登入</system:String>
+    <system:String x:Key="CharacterSummaryViewLogoutButtonText">注销</system:String>
 
 	<!-- CreateServerDialogView -->
 	<system:String x:Key="CreateServerDialogViewAddTitle">添加伺服器</system:String>

--- a/SIT.Manager/ViewModels/Play/CharacterSummaryViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/CharacterSummaryViewModel.cs
@@ -145,14 +145,6 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
             if (success && rememberLogin)
             {
                 _connectedServer.Characters.Add(character);
-
-                int index = _configService.Config.BookmarkedServers.FindIndex(x => x.Address == _connectedServer.Address);
-
-                if (index != -1 && !_configService.Config.BookmarkedServers[index].Characters.Any(x => x.Username == character.Username))
-                {
-                    _configService.Config.BookmarkedServers[index].Characters.Add(character);
-                }
-
                 _configService.UpdateConfig(_configService.Config);
                 RequireLogin = false;
             }
@@ -172,18 +164,9 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
 
     private async Task Logout()
     {
-        AkiCharacter? character = _connectedServer.Characters.FirstOrDefault(x => x.Username == Profile.Username);
-
         if (character != null)
         {
             _connectedServer.Characters.Remove(character);
-
-            int index = _configService.Config.BookmarkedServers.FindIndex(x => x.Address == _connectedServer.Address);
-
-            if (index != -1 && !_configService.Config.BookmarkedServers[index].Characters.Any(x => x.Username == character.Username))
-            {
-                _configService.Config.BookmarkedServers[index].Characters.Remove(character);
-            }
             _configService.UpdateConfig(_configService.Config);
             RequireLogin = true;
         }

--- a/SIT.Manager/ViewModels/Play/CharacterSummaryViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/CharacterSummaryViewModel.cs
@@ -9,6 +9,8 @@ using SIT.Manager.Models.Aki;
 using SIT.Manager.Services.Caching;
 using SIT.Manager.Views.Play;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -42,6 +44,8 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
     private bool _requireLogin = true;
 
     public IAsyncRelayCommand PlayCommand { get; }
+
+    public IAsyncRelayCommand LogoutCommand { get; }
 
     public CharacterSummaryViewModel(AkiServer server,
         AkiMiniProfile profile,
@@ -86,6 +90,7 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
         Task.Run(SetSideImage);
 
         PlayCommand = new AsyncRelayCommand(Play);
+        LogoutCommand = new AsyncRelayCommand(Logout);
     }
 
     private async Task SetSideImage()
@@ -140,11 +145,14 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
             if (success && rememberLogin)
             {
                 _connectedServer.Characters.Add(character);
+
                 int index = _configService.Config.BookmarkedServers.FindIndex(x => x.Address == _connectedServer.Address);
+
                 if (index != -1 && !_configService.Config.BookmarkedServers[index].Characters.Any(x => x.Username == character.Username))
                 {
                     _configService.Config.BookmarkedServers[index].Characters.Add(character);
                 }
+
                 _configService.UpdateConfig(_configService.Config);
                 RequireLogin = false;
             }
@@ -159,6 +167,25 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
                 PrimaryButtonText = _localizationService.TranslateSource("CharacterSummaryViewModelPlayErrorDialogPrimaryButtonText"),
             };
             await errorDialog.ShowAsync();
+        }
+    }
+
+    private async Task Logout()
+    {
+        AkiCharacter? character = _connectedServer.Characters.FirstOrDefault(x => x.Username == Profile.Username);
+
+        if (character != null)
+        {
+            _connectedServer.Characters.Remove(character);
+
+            int index = _configService.Config.BookmarkedServers.FindIndex(x => x.Address == _connectedServer.Address);
+
+            if (index != -1 && !_configService.Config.BookmarkedServers[index].Characters.Any(x => x.Username == character.Username))
+            {
+                _configService.Config.BookmarkedServers[index].Characters.Remove(character);
+            }
+            _configService.UpdateConfig(_configService.Config);
+            RequireLogin = true;
         }
     }
 }

--- a/SIT.Manager/Views/Play/CharacterSummaryView.axaml
+++ b/SIT.Manager/Views/Play/CharacterSummaryView.axaml
@@ -9,7 +9,7 @@
              x:Class="SIT.Manager.Views.Play.CharacterSummaryView"
 			 x:DataType="vm:CharacterSummaryViewModel">
 	<controls:Card Margin="8">
-		<Grid ColumnDefinitions="Auto, *, Auto">
+		<Grid ColumnDefinitions="Auto, *, Auto, Auto">
 			<StackPanel Grid.Column="0">
 				<Image Grid.Column="0"
 					VerticalAlignment="Center"
@@ -61,6 +61,15 @@
 							   Text="{DynamicResource CharacterSummaryViewLoginButtonText}"/>
 				</Panel>
 			</Button>
+
+			<Button Grid.Column="3"
+					Margin="14,0"
+                    Command="{Binding LogoutCommand}"
+                    IsVisible="{Binding !RequireLogin}">
+                <Panel>
+                    <TextBlock Text="{DynamicResource CharacterSummaryViewLogoutButtonText}"/>
+                </Panel>
+            </Button>
 		</Grid>
 	</controls:Card>
 </UserControl>


### PR DESCRIPTION
Useful if the PC is shared or if you, for whatever reason, need to share your SIT install.

New button only displays if the profile is a saved profile and updated localization files (using online translate tools) to add button text.

Character selection with a saved profile (remember me ticked on login dialog):

![Saved profile - logout button](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/fb72a3be-6ea9-48a1-9377-d68b6894b4c2)

After clicking on logout:

![Saved profile - logged out](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/11dfe1a8-d9e7-47c2-9f56-af64a0f1fa50)

ManagerConfig.json file is updated to remove the saved profile after clicking so that the next time the manager is started the profile is still logged out.