### PR TITLE
There is an issue where saving a profile causes duplicates in ManagerConfig.json

### DIFF
--- a/SIT.Manager/ViewModels/Play/CharacterSummaryViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/CharacterSummaryViewModel.cs
@@ -121,7 +121,10 @@ public partial class CharacterSummaryViewModel : ObservableRecipient
         }
 
         AkiCharacter? character = _connectedServer.Characters.FirstOrDefault(x => x.Username == Profile.Username);
-        bool rememberLogin = true;
+
+        // Set this to false rather than true - this was causing duplicate saved profiles
+        // If we were already logged on the code to see if EFT was launched AND remember password would pass and save a duplicate each time
+        bool rememberLogin = false;
 
         if (character == null)
         {


### PR DESCRIPTION
Duplicate entries end up looking like this (passwords blanked out):
![Issue](https://github.com/stayintarkov/SIT.Manager.Avalonia/assets/124541915/1b391265-af4f-4225-8715-3d4115bd549f)

This was caused by CharacterSummaryViewModel having the rememberLogin defaulting to true - if the profile was already saved the login box is not shown and this variable then remains true, which causes the code that checks to see if the connection to EFT was successful and rememberLogin was also true to add the profile to the config.  This variable has now been set to false.

Have also added a clean up routine in CharacterSelectionViewModel that removes all duplicate saved profiles (if there are any).  It chooses the profile to keep by grouping by username and password, then selecting either the first entry with a ProfileID or the first entry if there are no Profile ID's.  All profiles for that username/password are then removed, the profile to be kept placed back into the config and the configuration saved to disk.  This method is called when reloading the character list.  By adding this clean-up method people will not have to manually remove duplications from their config file - though this part can be removed at a later date.