### PR TITLE
Implement server nicknaming locally for users

### DIFF
--- a/SIT.Manager/Localization/en-US.axaml
+++ b/SIT.Manager/Localization/en-US.axaml
@@ -439,6 +439,8 @@
 	<system:String x:Key="CreateServerDialogViewCloseButtonText">Close</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressLabel">Address</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressTextBoxWatermark">Enter Server Address...</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameLabel">Nickname</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameTextBoxWatermark">Optional nickname for server...</system:String>
 
 	<!-- DirectConnectView -->
 	<system:String x:Key="DirectConnectViewAddressBoxTitle">Address</system:String>
@@ -467,6 +469,7 @@
 	<!-- ServerSummaryView -->
 	<system:String x:Key="ServerSummaryViewModelConnectButtonText">Connect</system:String>
 	<system:String x:Key="ServerSummaryViewModelPingUnitsText">ms</system:String>
+	<system:String x:Key="ServerSummaryViewServerConnectingText">Connecting...</system:String>
 
 	<!-- PlayPage -->
 	<system:String x:Key="PlayPageBookmarksTabHeader">Bookmarks</system:String>

--- a/SIT.Manager/Localization/ru-RU.axaml
+++ b/SIT.Manager/Localization/ru-RU.axaml
@@ -440,6 +440,8 @@
 	<system:String x:Key="CreateServerDialogViewCloseButtonText">Закрыть</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressLabel">Адрес</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressTextBoxWatermark">Введите адрес сервера...</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameLabel">Nickname</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameTextBoxWatermark">Optional nickname for server...</system:String>
 
 	<!-- DirectConnectView -->
 	<system:String x:Key="DirectConnectViewAddressBoxTitle">Адрес</system:String>
@@ -468,6 +470,7 @@
 	<!-- ServerSummaryView -->
 	<system:String x:Key="ServerSummaryViewModelConnectButtonText">Подключиться</system:String>
 	<system:String x:Key="ServerSummaryViewModelPingUnitsText">мс</system:String>
+	<system:String x:Key="ServerSummaryViewServerConnectingText">Connecting...</system:String>
 
 	<!-- PlayPage -->
 	<system:String x:Key="PlayPageBookmarksTabHeader">Закладки</system:String>

--- a/SIT.Manager/Localization/uk-UA.axaml
+++ b/SIT.Manager/Localization/uk-UA.axaml
@@ -441,6 +441,8 @@
 	<system:String x:Key="CreateServerDialogViewCloseButtonText">Закрити</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressLabel">Адреса</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressTextBoxWatermark">Введіть адресу сервера...</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameLabel">Nickname</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameTextBoxWatermark">Optional nickname for server...</system:String>
 
 	<!-- DirectConnectView -->
 	<system:String x:Key="DirectConnectViewAddressBoxTitle">Адреса</system:String>
@@ -469,6 +471,7 @@
 	<!-- ServerSummaryView -->
 	<system:String x:Key="ServerSummaryViewModelConnectButtonText">Підключитися</system:String>
 	<system:String x:Key="ServerSummaryViewModelPingUnitsText">мс</system:String>
+	<system:String x:Key="ServerSummaryViewServerConnectingText">Connecting...</system:String>
 
 	<!-- PlayPage -->
 	<system:String x:Key="PlayPageBookmarksTabHeader">Закладки</system:String>

--- a/SIT.Manager/Localization/zh-CN.axaml
+++ b/SIT.Manager/Localization/zh-CN.axaml
@@ -441,6 +441,8 @@
 	<system:String x:Key="CreateServerDialogViewCloseButtonText">关闭</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressLabel">地址</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressTextBoxWatermark">输入服务器地址...</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameLabel">Nickname</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameTextBoxWatermark">Optional nickname for server...</system:String>
 
 	<!-- DirectConnectView -->
 	<system:String x:Key="DirectConnectViewAddressBoxTitle">地址</system:String>
@@ -469,6 +471,7 @@
 	<!-- ServerSummaryView -->
 	<system:String x:Key="ServerSummaryViewModelConnectButtonText">连接</system:String>
 	<system:String x:Key="ServerSummaryViewModelPingUnitsText">毫秒</system:String>
+	<system:String x:Key="ServerSummaryViewServerConnectingText">Connecting...</system:String>
 
 	<!-- PlayPage -->
 	<system:String x:Key="PlayPageBookmarksTabHeader">书签</system:String>

--- a/SIT.Manager/Localization/zh-HK.axaml
+++ b/SIT.Manager/Localization/zh-HK.axaml
@@ -440,6 +440,8 @@
 	<system:String x:Key="CreateServerDialogViewCloseButtonText">關閉</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressLabel">地址</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressTextBoxWatermark">输入服务器地址...</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameLabel">Nickname</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameTextBoxWatermark">Optional nickname for server...</system:String>
 
 	<!-- DirectConnectView -->
 	<system:String x:Key="DirectConnectViewAddressBoxTitle">地址</system:String>
@@ -468,6 +470,7 @@
 	<!-- ServerSummaryView -->
 	<system:String x:Key="ServerSummaryViewModelConnectButtonText">連接</system:String>
 	<system:String x:Key="ServerSummaryViewModelPingUnitsText">毫秒</system:String>
+	<system:String x:Key="ServerSummaryViewServerConnectingText">Connecting...</system:String>
 
 	<!-- PlayPage -->
 	<system:String x:Key="PlayPageBookmarksTabHeader">書籤</system:String>

--- a/SIT.Manager/Localization/zh-TW.axaml
+++ b/SIT.Manager/Localization/zh-TW.axaml
@@ -441,6 +441,8 @@
 	<system:String x:Key="CreateServerDialogViewCloseButtonText">關閉</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressLabel">地址</system:String>
 	<system:String x:Key="CreateServerDialogViewAddressTextBoxWatermark">輸入服务器地址...</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameLabel">Nickname</system:String>
+	<system:String x:Key="CreateServerDialogViewNicknameTextBoxWatermark">Optional nickname for server...</system:String>
 
 	<!-- DirectConnectView -->
 	<system:String x:Key="DirectConnectViewAddressBoxTitle">地址</system:String>
@@ -469,6 +471,7 @@
 	<!-- ServerSummaryView -->
 	<system:String x:Key="ServerSummaryViewModelConnectButtonText">連接</system:String>
 	<system:String x:Key="ServerSummaryViewModelPingUnitsText">毫秒</system:String>
+	<system:String x:Key="ServerSummaryViewServerConnectingText">Connecting...</system:String>
 
 	<!-- PlayPage -->
 	<system:String x:Key="PlayPageBookmarksTabHeader">書籤</system:String>

--- a/SIT.Manager/Models/Aki/AkiServer.cs
+++ b/SIT.Manager/Models/Aki/AkiServer.cs
@@ -11,6 +11,8 @@ public partial class AkiServer(Uri address) : ObservableObject
     public Uri Address { get; } = address;
     [JsonPropertyName("Characters")]
     public List<AkiCharacter> Characters { get; init; } = [];
+    [JsonPropertyName("Nickname")]
+    public string Nickname { get; set; } = string.Empty;
     [JsonIgnore]
     public string Name { get; internal set; } = string.Empty;
     [JsonIgnore]

--- a/SIT.Manager/Models/Play/CreateServerDialogResult.cs
+++ b/SIT.Manager/Models/Play/CreateServerDialogResult.cs
@@ -1,0 +1,8 @@
+﻿using FluentAvalonia.UI.Controls;
+using System;
+
+namespace SIT.Manager.Models.Play;
+
+public record CreateServerDialogResult(ContentDialogResult DialogResult,
+    Uri ServerUri,
+    string ServerNickname);

--- a/SIT.Manager/ViewModels/Play/CreateServerDialogViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/CreateServerDialogViewModel.cs
@@ -9,9 +9,13 @@ public partial class CreateServerDialogViewModel : ObservableValidator
 {
     private readonly ILocalizationService _localizationService;
 
+    [ObservableProperty]
+    private string _serverNickname = string.Empty;
+
     private string _serverAddress = string.Empty;
 
     [CustomValidation(typeof(CreateServerDialogViewModel), nameof(ValidateAddress))]
+    [Required]
     public string ServerAddress
     {
         get => _serverAddress;
@@ -28,11 +32,12 @@ public partial class CreateServerDialogViewModel : ObservableValidator
 
     public string AddOrEditTitle { get; }
 
-    public CreateServerDialogViewModel(string currentServerAddress, bool isEdit, ILocalizationService localizationService)
+    public CreateServerDialogViewModel(string currentServerAddress, string serverNickname, bool isEdit, ILocalizationService localizationService)
     {
         _localizationService = localizationService;
 
         ServerAddress = currentServerAddress;
+        ServerNickname = serverNickname;
 
         if (isEdit)
         {

--- a/SIT.Manager/ViewModels/Play/ServerSelectionViewModel.cs
+++ b/SIT.Manager/ViewModels/Play/ServerSelectionViewModel.cs
@@ -39,15 +39,18 @@ public partial class ServerSelectionViewModel : ObservableRecipient, IRecipient<
 
     private async Task CreateServer()
     {
-        CreateServerDialogView dialog = new(_localizationService, false);
-        (ContentDialogResult result, Uri serverUri) = await dialog.ShowAsync();
-        if (result == ContentDialogResult.Primary)
+        CreateServerDialogView dialog = new(_localizationService, false, string.Empty);
+        CreateServerDialogResult result = await dialog.ShowAsync();
+        if (result.DialogResult == ContentDialogResult.Primary)
         {
             bool serverExists = _configService.Config.BookmarkedServers
-                .Any(x => Uri.Compare(x.Address, serverUri, UriComponents.HostAndPort, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) == 0);
+                .Any(x => Uri.Compare(x.Address, result.ServerUri, UriComponents.HostAndPort, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) == 0);
             if (!serverExists)
             {
-                AkiServer newServer = new(serverUri);
+                AkiServer newServer = new(result.ServerUri)
+                {
+                    Nickname = result.ServerNickname
+                };
                 ServerList.Add(ActivatorUtilities.CreateInstance<ServerSummaryViewModel>(_serviceProvider, newServer));
                 _configService.Config.BookmarkedServers.Add(newServer);
                 _configService.UpdateConfig(_configService.Config);

--- a/SIT.Manager/Views/Play/CreateServerDialogView.axaml
+++ b/SIT.Manager/Views/Play/CreateServerDialogView.axaml
@@ -18,5 +18,10 @@
 				 MinWidth="300" 
 				 HorizontalAlignment="Left" 
 				 Watermark="{DynamicResource CreateServerDialogViewAddressTextBoxWatermark}"/>
+		<Label Content="{DynamicResource CreateServerDialogViewNicknameLabel}" FontWeight="SemiBold"/>
+		<TextBox Text="{Binding ServerNickname, Mode=TwoWay}"
+				 MinWidth="300"
+				 HorizontalAlignment="Left"
+				 Watermark="{DynamicResource CreateServerDialogViewNicknameTextBoxWatermark}"/>
 	</StackPanel>
 </ui:ContentDialog>

--- a/SIT.Manager/Views/Play/CreateServerDialogView.axaml.cs
+++ b/SIT.Manager/Views/Play/CreateServerDialogView.axaml.cs
@@ -1,5 +1,6 @@
 using FluentAvalonia.UI.Controls;
 using SIT.Manager.Interfaces;
+using SIT.Manager.Models.Play;
 using SIT.Manager.ViewModels.Play;
 using System;
 using System.Threading.Tasks;
@@ -14,15 +15,15 @@ public partial class CreateServerDialogView : ContentDialog
 
     protected override Type StyleKeyOverride => typeof(ContentDialog);
 
-    public CreateServerDialogView(ILocalizationService localizationService, bool isEdit, string currentServerAddress = DEFAULT_SERVER_ADDRESS)
+    public CreateServerDialogView(ILocalizationService localizationService, bool isEdit, string serverNickname, string currentServerAddress = DEFAULT_SERVER_ADDRESS)
     {
-        dc = new CreateServerDialogViewModel(currentServerAddress, isEdit, localizationService);
+        dc = new CreateServerDialogViewModel(currentServerAddress, serverNickname, isEdit, localizationService);
         DataContext = dc;
         InitializeComponent();
     }
 
-    public new Task<(ContentDialogResult, Uri)> ShowAsync()
+    public new Task<CreateServerDialogResult> ShowAsync()
     {
-        return ShowAsync(null).ContinueWith(t => (t.Result, dc.ServerUri));
+        return ShowAsync(null).ContinueWith(t => new CreateServerDialogResult(t.Result, dc.ServerUri, dc.ServerNickname));
     }
 }

--- a/SIT.Manager/Views/Play/ServerSummaryView.axaml
+++ b/SIT.Manager/Views/Play/ServerSummaryView.axaml
@@ -27,10 +27,10 @@
 
 			<StackPanel Grid.Column="1"
 						Margin="8,0">
-				<TextBlock Text="{Binding Name}"
+				<TextBlock Text="{Binding ServerDisplayName}"
 						   FontSize="24"
 						   IsVisible="{Binding !IsLoading}"/>
-				<TextBlock Text="Connecting..."
+				<TextBlock Text="{DynamicResource ServerSummaryViewServerConnectingText}"
 						   FontSize="24"
 						   IsVisible="{Binding IsLoading}"/>
 


### PR DESCRIPTION
Resolve #267 by adding an optional entry in the edit server and add server dialogs to set a nickname for the server.

This nickname overrides whatever the server name is set to and displays that instead, if a user wants to see the real server name again then they just have to unset the nickname by editing the server entry to remove it.