### PR TITLE
Remove custom cert delegate

### DIFF
--- a/SIT.Manager/App.axaml.cs
+++ b/SIT.Manager/App.axaml.cs
@@ -98,8 +98,7 @@ public sealed partial class App : Application
                 //TODO: Move this to httpclient factory with proper configuration
                 .AddSingleton(new HttpClientHandler
                 {
-                    SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
-                    ServerCertificateCustomValidationCallback = delegate { return true; }
+                    SslProtocols = System.Security.Authentication.SslProtocols.Tls12
                 })
                 .AddSingleton(provider => new HttpClient(provider.GetService<HttpClientHandler>() ?? throw new ArgumentNullException())
                 {


### PR DESCRIPTION
This was carried over from the old manager without question. I see no reason for this to be here and so we're axing it for security